### PR TITLE
c-s: basic CLI arguments parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
@@ -46,7 +46,7 @@ checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.101",
 ]
 
 [[package]]
@@ -169,14 +169,18 @@ dependencies = [
  "env_logger",
  "futures",
  "hdrhistogram",
+ "lazy_static",
  "ntest",
  "openssl",
  "parking_lot",
  "rand",
  "rand_distr",
  "rand_pcg",
+ "regex",
  "scylla",
  "sha2",
+ "strum 0.25.0",
+ "strum_macros 0.25.1",
  "thread_local",
  "tokio",
  "tracing",
@@ -343,7 +347,7 @@ checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.101",
 ]
 
 [[package]]
@@ -427,6 +431,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,6 +487,12 @@ checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -586,7 +602,7 @@ checksum = "6f7caf063242bb66721e74515dc01a915901063fa1f994bee7a2b9136f13370e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.101",
 ]
 
 [[package]]
@@ -599,7 +615,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.101",
 ]
 
 [[package]]
@@ -661,7 +677,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.101",
 ]
 
 [[package]]
@@ -693,7 +709,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.101",
 ]
 
 [[package]]
@@ -769,18 +785,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.46"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -845,9 +861,21 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d3daa6976cffb758ec878f108ba0e062a45b2d6ca3a2cca965338855476caf"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -856,9 +884,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.27"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "rustversion"
@@ -898,8 +926,8 @@ dependencies = [
  "scylla-macros",
  "smallvec",
  "snap",
- "strum",
- "strum_macros",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
  "thiserror",
  "tokio",
  "tokio-openssl",
@@ -936,7 +964,7 @@ checksum = "32d777dadbf7163d1524ea4f5a095146298d263a686febb96d022cf46d06df32"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.101",
 ]
 
 [[package]]
@@ -1009,16 +1037,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
 
 [[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+
+[[package]]
 name = "strum_macros"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.101",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6069ca09d878a33f883cc06aaa9718ede171841d3832450354410b718b097232"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1026,6 +1073,17 @@ name = "syn"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1058,7 +1116,7 @@ checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.101",
 ]
 
 [[package]]
@@ -1109,7 +1167,7 @@ checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.101",
 ]
 
 [[package]]
@@ -1154,7 +1212,7 @@ checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.101",
 ]
 
 [[package]]
@@ -1248,7 +1306,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -1270,7 +1328,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,17 @@ chrono = "0.4.9"
 env_logger = "0.9.0"
 futures = "0.3.19"
 hdrhistogram = "7.5.0"
+lazy_static = "1.4.0"
 openssl = "0.10.32"
 parking_lot = "0.12.0"
 rand = "0.8"
 rand_distr = "0.4"
 rand_pcg = "0.3"
+regex = "1.9.1"
 scylla = {version = "0.8.1", features = ["ssl"]}
 sha2 = "0.10"
+strum = "0.25.0"
+strum_macros = "0.25.1"
 thread_local = "1.1.4"
 tokio = {version = "1.15.0", features = ["full"]}# TODO: Include only necessary features
 tracing = {version = "0.1.35", features = ["log"]}

--- a/src/bin/cql-stress-cassandra-stress/main.rs
+++ b/src/bin/cql-stress-cassandra-stress/main.rs
@@ -1,3 +1,30 @@
-fn main() {
-    todo!("The cassandra-stress frontend is not implemented yet");
+mod settings;
+
+#[macro_use]
+extern crate lazy_static;
+
+use crate::settings::parse_cassandra_stress_args;
+use anyhow::Result;
+use std::env;
+
+use settings::CassandraStressParsingResult;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Cassandra-stress CLI is case-insensitive.
+    let payload = match parse_cassandra_stress_args(env::args().map(|arg| arg.to_lowercase())) {
+        // Special commands: help, print, version
+        Ok(CassandraStressParsingResult::SpecialCommand) => return Ok(()),
+        Ok(CassandraStressParsingResult::Workload(payload)) => payload,
+        Err(e) => {
+            // For some reason cassandra-stress writes all parsing-related
+            // error messages to stdout. We will follow the same approach.
+            println!("\n{e}");
+            return Err(anyhow::anyhow!("Failed to parse CLI arguments."));
+        }
+    };
+
+    payload.print_settings();
+
+    Ok(())
 }

--- a/src/bin/cql-stress-cassandra-stress/settings/command/help.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/help.rs
@@ -1,0 +1,44 @@
+use anyhow::Result;
+
+use crate::settings::command::Command;
+
+use super::{CommandParams, ParsePayload};
+
+pub fn print_help() {
+    println!("Usage:      cassandra-stress <command> [options]");
+    println!("Help usage: cassandra-stress help <command|option>");
+    println!();
+    Command::print_generic_help();
+    // TODO: Add corresponding call for supported options once we introduce them.
+}
+
+fn print_command_help(command_str: &str) -> Result<CommandParams> {
+    match Command::parse(command_str) {
+        Ok(cmd) => {
+            cmd.print_help();
+            Ok(CommandParams::Special)
+        }
+        Err(_) => Err(anyhow::anyhow!(
+            "Invalid command or option provided to command help"
+        )),
+    }
+}
+
+pub fn parse_help_command(payload: &mut ParsePayload) -> Result<CommandParams> {
+    let params = payload.remove("help").unwrap();
+    if params.is_empty() && payload.is_empty() {
+        print_help();
+        return Ok(CommandParams::Special);
+    }
+
+    anyhow::ensure!(
+        params.len() + payload.len() == 1,
+        "Invalid command/option provided to help",
+    );
+
+    if !params.is_empty() {
+        return print_command_help(params[0]);
+    }
+
+    todo!("Implement help for options.");
+}

--- a/src/bin/cql-stress-cassandra-stress/settings/command/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/mod.rs
@@ -1,0 +1,107 @@
+use std::convert::AsRef;
+use std::str::FromStr;
+use strum::IntoEnumIterator;
+use strum::ParseError;
+use strum_macros::AsRefStr;
+use strum_macros::EnumIter;
+use strum_macros::EnumString;
+
+use anyhow::Result;
+
+mod help;
+mod read_write;
+
+use self::read_write::{parse_read_write_params, print_help_read_write};
+pub use help::print_help;
+
+use super::ParsePayload;
+use help::parse_help_command;
+use read_write::ReadWriteParams;
+
+#[derive(Clone, Debug, PartialEq, Eq, EnumIter, AsRefStr, EnumString)]
+#[strum(serialize_all = "snake_case")]
+#[strum(ascii_case_insensitive)]
+pub enum Command {
+    Help,
+    Write,
+    Read,
+    CounterWrite,
+    CounterRead,
+}
+
+impl Command {
+    fn parse(cmd: &str) -> Result<Self, ParseError> {
+        Self::from_str(cmd)
+    }
+
+    fn parse_params(&self, payload: &mut ParsePayload) -> Result<CommandParams> {
+        match self {
+            Command::Read | Command::Write | Command::CounterRead | Command::CounterWrite => {
+                parse_read_write_params(self, payload)
+            }
+            Command::Help => parse_help_command(payload),
+        }
+    }
+
+    pub fn show(&self) -> &str {
+        self.as_ref()
+    }
+
+    fn print_short_description(&self) {
+        let desc = match self {
+            Command::Read => "Multiple concurrent reads - the cluster must first be populated by a write test.",
+            Command::Write => "Multiple concurrent writes against the cluster.",
+            Command::CounterWrite => "Multiple concurrent updates of counters.",
+            Command::CounterRead => "Multiple concurrent reads of counters. The cluster must first be populated by a counterwrite test.",
+            Command::Help => "Print help for a command or option",
+        };
+
+        println!("{:<20} : {}", self.show(), desc);
+    }
+
+    fn print_generic_help() {
+        println!("---Commands---");
+        for cmd in Self::iter() {
+            cmd.print_short_description();
+        }
+    }
+
+    fn print_help(&self) {
+        match self {
+            Command::Read | Command::Write | Command::CounterRead | Command::CounterWrite => {
+                print_help_read_write(self.show())
+            }
+            Command::Help => help::print_help(),
+        }
+    }
+}
+
+pub enum CommandParams {
+    // HELP, PRINT, VERSION
+    Special,
+
+    // READ, WRITE, COUNTER_READ, COUNTER_WRITE
+    BasicParams(ReadWriteParams),
+    // MIXED
+    // TODO: MixedParams,
+
+    // USER
+    // TODO: UserParams,
+}
+
+impl CommandParams {
+    pub fn print_settings(&self, cmd: &Command) {
+        if let Self::BasicParams(params) = self {
+            params.print_settings(cmd);
+        }
+    }
+}
+
+pub fn parse_command(
+    command_str: &str,
+    cl_args: &mut ParsePayload,
+) -> Result<(Command, CommandParams)> {
+    let command = Command::parse(command_str)?;
+    let params = command.parse_params(cl_args)?;
+    Ok((command, params))
+}

--- a/src/bin/cql-stress-cassandra-stress/settings/command/read_write.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/read_write.rs
@@ -1,0 +1,406 @@
+use crate::settings::{
+    param::{ParamsParser, SimpleParamHandle},
+    ParsePayload,
+};
+use anyhow::{Context, Result};
+use std::str::FromStr;
+use strum_macros::{AsRefStr, EnumString};
+
+use super::{Command, CommandParams};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Uncertainty {
+    pub target_uncertainty: f32,
+    pub min_uncertainty_measurements: u64,
+    pub max_uncertainty_measurements: u64,
+}
+
+impl Uncertainty {
+    pub fn new(
+        target_uncertainty: f32,
+        min_uncertainty_measurements: u64,
+        max_uncertainty_measurements: u64,
+    ) -> Self {
+        Self {
+            target_uncertainty,
+            min_uncertainty_measurements,
+            max_uncertainty_measurements,
+        }
+    }
+
+    pub fn print_settings(&self) {
+        println!("  Target Uncertainty: {}", self.target_uncertainty);
+        println!(
+            "  Minimum Uncertainty Measurements: {}",
+            self.min_uncertainty_measurements
+        );
+        println!(
+            "  Maximum Uncertainty Measurements: {}",
+            self.max_uncertainty_measurements
+        );
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, AsRefStr, EnumString)]
+#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
+#[strum(ascii_case_insensitive)]
+pub enum Truncate {
+    Never,
+    Once,
+    Always,
+}
+
+impl Truncate {
+    fn parse(truncate: &str) -> Result<Self> {
+        Self::from_str(truncate).with_context(|| format!("Invalid truncate type: {}", truncate))
+    }
+
+    fn show(&self) -> &str {
+        self.as_ref()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, AsRefStr, EnumString)]
+#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
+#[strum(ascii_case_insensitive)]
+pub enum ConsistencyLevel {
+    One,
+    Quorum,
+    LocalQuorum,
+    EachQuorum,
+    All,
+    Any,
+    Two,
+    Three,
+    LocalOne,
+    Serial,
+    LocalSerial,
+}
+
+impl ConsistencyLevel {
+    fn parse(cl: &str) -> Result<Self> {
+        Self::from_str(cl).with_context(|| format!("Invalid consistency level: {}", cl))
+    }
+
+    fn show(&self) -> &str {
+        self.as_ref()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, AsRefStr, EnumString)]
+#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
+#[strum(ascii_case_insensitive)]
+pub enum SerialConsistencyLevel {
+    Serial,
+    LocalSerial,
+}
+
+impl SerialConsistencyLevel {
+    fn parse(serial_cl: &str) -> Result<Self> {
+        Self::from_str(serial_cl)
+            .with_context(|| format!("Invalid serial consistency level: {}", serial_cl))
+    }
+
+    fn show(&self) -> &str {
+        self.as_ref()
+    }
+}
+
+pub struct ReadWriteParams {
+    pub uncertainty: Option<Uncertainty>,
+    pub no_warmup: bool,
+    pub truncate: Truncate,
+    pub consistency_level: ConsistencyLevel,
+    pub serial_consistency_level: SerialConsistencyLevel,
+    pub operation_count: Option<u64>,
+    pub duration: Option<u64>,
+}
+
+impl ReadWriteParams {
+    pub fn print_settings(&self, command: &Command) {
+        println!("Command:");
+        println!("  Type: {}", command.show());
+        print!("  Count: ");
+        match &self.operation_count {
+            Some(v) => println!("{v}"),
+            None => println!("-1"),
+        }
+        if self.duration.is_some() {
+            println!("  Duration: {} SECONDS", self.duration.unwrap());
+        }
+        println!("  No Warmup: {}", self.no_warmup);
+        println!("  Consistency Level: {}", self.consistency_level.show());
+        println!(
+            "  Serial Consistency Level: {}",
+            self.serial_consistency_level.show()
+        );
+        println!("  Truncate: {}", self.truncate.show());
+        if self.uncertainty.is_none() {
+            println!("  Target Uncertainty: not applicable");
+        } else {
+            self.uncertainty.as_ref().unwrap().print_settings();
+        }
+    }
+}
+
+struct ReadWriteParamHandles {
+    err: SimpleParamHandle,
+    ngt: SimpleParamHandle,
+    nlt: SimpleParamHandle,
+    no_warmup: SimpleParamHandle,
+    truncate: SimpleParamHandle,
+    cl: SimpleParamHandle,
+    serial_cl: SimpleParamHandle,
+    n: SimpleParamHandle,
+    duration: SimpleParamHandle,
+}
+
+fn parse_operation_count_unit(unit: char) -> Result<u64> {
+    match unit {
+        'k' => Ok(1_000),
+        'm' => Ok(1_000_000),
+        'b' => Ok(1_000_000_000),
+        _ => Err(anyhow::anyhow!("Invalid operation count unit: {}", unit)),
+    }
+}
+
+fn parse_operation_count(n: &str) -> Result<u64> {
+    let last = n.chars().last().unwrap();
+    let mut multiplier = 1;
+    let mut number_slice = n;
+    if last.is_alphabetic() {
+        multiplier = parse_operation_count_unit(last)?;
+        number_slice = &n[0..n.len() - 1];
+    }
+    Ok(number_slice.parse::<u64>().unwrap() * multiplier)
+}
+
+fn parse_duration_unit(unit: char) -> Result<u64> {
+    match unit {
+        's' => Ok(1),
+        'm' => Ok(60),
+        'h' => Ok(60 * 60),
+        _ => Err(anyhow::anyhow!("Invalid duration unit: {}", unit)),
+    }
+}
+
+fn parse_duration(n: &str) -> Result<u64> {
+    let multiplier = parse_duration_unit(n.chars().last().unwrap())?;
+    Ok(n[0..n.len() - 1].parse::<u64>().unwrap() * multiplier)
+}
+
+fn prepare_parser(cmd: &str) -> (ParamsParser, ReadWriteParamHandles) {
+    let mut parser = ParamsParser::new(cmd);
+    let err = parser.simple_param(
+        "err<",
+        r"^0\.[0-9]+$",
+        Some("0.02"),
+        "Run until the standard error of the mean is below this fraction",
+        false,
+    );
+    let ngt = parser.simple_param(
+        "n>",
+        r"^[0-9]+$",
+        Some("30"),
+        "Run at least this many iterations before accepting uncertainty convergence",
+        false,
+    );
+    let nlt = parser.simple_param(
+        "n<",
+        r"^[0-9]+$",
+        Some("200"),
+        "Run at most this many iterations before accepting uncertainty convergence",
+        false,
+    );
+    let no_warmup =
+        parser.simple_param("no-warmup", r"^$", None, "Do not warmup the process", false);
+    let truncate = parser.simple_param(
+        "truncate=",
+        r"^(never|once|always)$",
+        Some("never"),
+        "Truncate the table: never, before performing any work, or before each iteration",
+        false,
+    );
+    let cl = parser.simple_param(
+        "cl=",
+        r"^(one|quorum|local_quorum|each_quorum|all|any|two|three|local_one|serial|local_serial)$",
+        Some("local_one"),
+        "Consistency level to use",
+        false,
+    );
+    let serial_cl = parser.simple_param(
+        "serial-cl=",
+        r"^(serial|local_serial)$",
+        Some("serial"),
+        "Serial consistency level to use",
+        false,
+    );
+    let n = parser.simple_param(
+        "n=",
+        r"^[0-9]+[bmk]?$",
+        None,
+        "Number of operations to perform",
+        true,
+    );
+    let duration = parser.simple_param(
+        "duration=",
+        r"^[0-9]+[smh]$",
+        None,
+        "Time to run in (in seconds, minutes or hours)",
+        true,
+    );
+
+    // $ ./cassandra-stress help read
+    //
+    // Usage: read [err<?] [n>?] [n<?] [no-warmup] [truncate=?] [cl=?] [serial-cl=?]
+    //  OR
+    // Usage: read n=? [no-warmup] [truncate=?] [cl=?] [serial-cl=?]
+    //  OR
+    // Usage: read duration=? [no-warmup] [truncate=?] [cl=?] [serial-cl=?]
+    parser.group(vec![
+        &err, &ngt, &nlt, &no_warmup, &truncate, &cl, &serial_cl,
+    ]);
+    parser.group(vec![&n, &no_warmup, &truncate, &cl, &serial_cl]);
+    parser.group(vec![&duration, &no_warmup, &truncate, &cl, &serial_cl]);
+
+    (
+        parser,
+        ReadWriteParamHandles {
+            err,
+            ngt,
+            nlt,
+            no_warmup,
+            truncate,
+            cl,
+            serial_cl,
+            n,
+            duration,
+        },
+    )
+}
+
+fn parse_with_handles(handles: ReadWriteParamHandles) -> ReadWriteParams {
+    let err = handles.err.get_type::<f32>();
+    let ngt = handles.ngt.get_type::<u64>();
+    let nlt = handles.nlt.get_type::<u64>();
+    let no_warmup = handles.no_warmup.supplied_by_user();
+    let truncate = Truncate::parse(&handles.truncate.get().unwrap()).unwrap();
+    let consistency_level = ConsistencyLevel::parse(&handles.cl.get().unwrap()).unwrap();
+    let serial_consistency_level =
+        SerialConsistencyLevel::parse(&handles.serial_cl.get().unwrap()).unwrap();
+    let operation_count = handles.n.get().map(|n| parse_operation_count(&n).unwrap());
+    let duration = handles.duration.get().map(|d| parse_duration(&d).unwrap());
+
+    let uncertainty = match (err, ngt, nlt) {
+        (Some(err), Some(ngt), Some(nlt)) => Some(Uncertainty::new(err, ngt, nlt)),
+        _ => None,
+    };
+
+    // Parser's regular expressions ensure that String parsing won't fail.
+    ReadWriteParams {
+        uncertainty,
+        no_warmup,
+        truncate,
+        consistency_level,
+        serial_consistency_level,
+        operation_count,
+        duration,
+    }
+}
+
+pub fn parse_read_write_params(cmd: &Command, payload: &mut ParsePayload) -> Result<CommandParams> {
+    let args = payload.remove(cmd.show()).unwrap();
+    let (parser, handles) = prepare_parser(cmd.show());
+    parser.parse(args)?;
+    Ok(CommandParams::BasicParams(parse_with_handles(handles)))
+}
+
+pub fn print_help_read_write(command_str: &str) {
+    let (parser, _) = prepare_parser(command_str);
+    parser.print_help();
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::settings::command::{
+        read_write::{
+            parse_with_handles, prepare_parser, ConsistencyLevel, SerialConsistencyLevel, Truncate,
+        },
+        Command,
+    };
+
+    const CMD: Command = Command::Read;
+
+    #[test]
+    fn read_params_parser_with_operation_count_test() {
+        let args = vec!["n=10m", "cl=quorum", "no-warmup"];
+        let (parser, handles) = prepare_parser(CMD.show());
+
+        assert!(parser.parse(args).is_ok());
+
+        let params = parse_with_handles(handles);
+
+        assert_eq!(None, params.uncertainty);
+        assert!(params.no_warmup);
+        assert_eq!(Truncate::Never, params.truncate);
+        assert_eq!(ConsistencyLevel::Quorum, params.consistency_level);
+        assert_eq!(
+            SerialConsistencyLevel::Serial,
+            params.serial_consistency_level
+        );
+        assert_eq!(Some(10_000_000), params.operation_count);
+        assert_eq!(None, params.duration);
+    }
+
+    #[test]
+    fn read_params_parser_with_uncertainty_test() {
+        let args = vec!["err<0.02", "n<1000", "no-warmup"];
+
+        let (parser, handles) = prepare_parser(CMD.show());
+
+        assert!(parser.parse(args).is_ok());
+
+        let params = parse_with_handles(handles);
+
+        assert_eq!(
+            0.02,
+            params.uncertainty.as_ref().unwrap().target_uncertainty
+        );
+        assert_eq!(
+            1000,
+            params
+                .uncertainty
+                .as_ref()
+                .unwrap()
+                .max_uncertainty_measurements
+        );
+        assert_eq!(
+            30,
+            params
+                .uncertainty
+                .as_ref()
+                .unwrap()
+                .min_uncertainty_measurements
+        );
+        assert!(params.no_warmup);
+        assert_eq!(Truncate::Never, params.truncate);
+        assert_eq!(ConsistencyLevel::LocalOne, params.consistency_level);
+        assert_eq!(
+            SerialConsistencyLevel::Serial,
+            params.serial_consistency_level
+        );
+        assert_eq!(None, params.operation_count);
+        assert_eq!(None, params.duration);
+    }
+
+    #[test]
+    fn read_params_groups_test() {
+        // Here we declare uncertainty parameters (err< and n<) with operation count parameter (n=).
+        // These two are mutually exclusive so the parsing should fail.
+        let args = vec!["err<0.02", "n<1000", "n=10m"];
+
+        let (parser, _) = prepare_parser(CMD.show());
+
+        assert!(parser.parse(args).is_err());
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/settings/cs_args_bad_test.in
+++ b/src/bin/cql-stress-cassandra-stress/settings/cs_args_bad_test.in
@@ -1,0 +1,10 @@
+cassandra-stress write cl=ONE n=10000 duration=10s
+cassandra-stress write n=10k err<0.2
+cassandra-stress write n=10000p
+cassandra-stress write cl=foo
+cassandra-stress write duration=1h n<10
+cassandra-stress write no-warmup=foo
+cassandra-stress counter_read duration=1hour
+cassandra-stress foo
+cassandra-stress help foo
+cassandra-stress write cl=local_one cl=quorum

--- a/src/bin/cql-stress-cassandra-stress/settings/cs_args_good_test.in
+++ b/src/bin/cql-stress-cassandra-stress/settings/cs_args_good_test.in
@@ -1,0 +1,12 @@
+cassandra-stress write cl=ONE n=10000
+cassandra-stress write no-warmup cl=quorum n=10b truncate=always
+cassandra-stress counter_read cl=QUORUM duration=5760m
+cassandra-stress write no-warmup cl=QUORUM duration=30m
+cassandra-stress write no-warmup serial-cl=LOCAL_SERIAL
+cassandra-stress write err<0.2 n>20
+cassandra-stress write
+cassandra-stress read
+cassandra-stress counter_read
+cassandra-stress counter_write
+cassandra-stress help
+cassandra-stress help read

--- a/src/bin/cql-stress-cassandra-stress/settings/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/mod.rs
@@ -1,0 +1,159 @@
+use std::collections::HashMap;
+use std::iter::Iterator;
+
+mod command;
+mod param;
+use anyhow::Result;
+
+#[cfg(test)]
+mod test;
+
+use command::Command;
+use command::CommandParams;
+use regex::Regex;
+
+use crate::settings::command::print_help;
+
+use self::command::parse_command;
+
+pub struct CassandraStressSettings {
+    pub command: Command,
+    pub params: CommandParams,
+}
+
+impl CassandraStressSettings {
+    fn new(command: Command, params: CommandParams) -> Self {
+        Self { command, params }
+    }
+
+    pub fn print_settings(&self) {
+        println!("******************** Stress Settings ********************");
+        self.params.print_settings(&self.command);
+        println!();
+    }
+}
+
+pub enum CassandraStressParsingResult {
+    // HELP, PRINT, VERSION
+    SpecialCommand,
+    Workload(Box<CassandraStressSettings>),
+}
+
+type ParsePayload<'a> = HashMap<&'a str, Vec<&'a str>>;
+
+/// Groups the commands/options and their corresponding parametes.
+///
+/// cassandra-stress accepts CLI args of the following pattern:
+/// ./cassandra-stress COMMAND [command_param...] [OPTION [option_param...]...]
+fn prepare_parse_payload(args: &[String]) -> Result<(&str, ParsePayload)> {
+    let mut cl_args: ParsePayload = HashMap::new();
+    let mut current: &str = "";
+    let mut cmd: &str = "";
+    for (i, arg) in args.iter().enumerate() {
+        let arg = arg.as_ref();
+        if i == 0 {
+            cmd = arg;
+        }
+        if i == 0 || arg.starts_with('-') {
+            anyhow::ensure!(
+                !cl_args.contains_key(arg),
+                "{} is defined multiple times. Each option/command can be specified at most once.",
+                arg
+            );
+            current = arg;
+            cl_args.insert(arg, vec![]);
+            continue;
+        }
+
+        let params = cl_args.get_mut(current).unwrap();
+        params.push(arg);
+    }
+
+    Ok((cmd, cl_args))
+}
+
+// Regular expressions used in `repair_params` function.
+lazy_static! {
+    // Removes whitespaces before characters: ,=()
+    static ref WHITESPACE_BEFORE: Regex = Regex::new(r"\s+([,=()])").unwrap();
+    // Removes whitespaces after characters: ,=(
+    static ref WHITESPACE_AFTER: Regex = Regex::new(r"([,=(])\s+").unwrap();
+
+    // Example:
+    // write -schema 'replication ( factor = 3 , foo = bar )'
+    // will be transformed to:
+    // ["write", "-schema", "replication(factor=3,foo=bar)"]
+    //
+    // The reason why WHITESPACE_AFTER doesn't contain ')' character:
+    // Take for example:
+    // write -schema 'replication(factor=3) ' keyspace=k
+    // After concatenating parameters to single string we get:
+    // "write -schema replication(factor=3)  keyspace=k"
+    // Note two spaces after ')'.
+    // Now if we replaced ")  " with ")", the resulting vector would be:
+    // ["write", "-schema", "replication(factor=3)keyspace=k"]
+
+    // Splits the resulting arguments by whitespaces.
+    static ref WHITESPACE_REGEX: Regex = Regex::new(r"\s+").unwrap();
+}
+
+/// Removes the unnecessary whitespaces from the arguments,
+/// and then splits the arguments that contain whitespaces.
+/// For example when user passes following arguments (cassandra-stress accepts such command):
+/// read -rate 'threads=80 throttle=8000/s'
+///
+/// Note that 'threads=80 throttle=8000/s' will be treated as a single string,
+/// so we need to split this into two separate parameters.
+/// The resulting vector would in this case be:
+/// ["read", "-rate", "threads=80", "throttle=8000/s"]
+fn repair_params<'a, I, S>(args: I) -> Vec<String>
+where
+    I: Iterator<Item = &'a S>,
+    S: AsRef<str> + 'a,
+{
+    // Concat to single string.
+    let args = args.map(|s| s.as_ref()).collect::<Vec<&str>>().join(" ");
+
+    let replaced = WHITESPACE_BEFORE.replace_all(&args, "$1");
+    let replaced = WHITESPACE_AFTER.replace_all(&replaced, "$1");
+    WHITESPACE_REGEX
+        .split(&replaced)
+        .map(&str::to_owned)
+        .collect()
+}
+
+pub fn parse_cassandra_stress_args<I, S>(mut args: I) -> Result<CassandraStressParsingResult>
+where
+    I: Iterator<Item = S>,
+    S: AsRef<str>,
+{
+    let _program_name = args.next().unwrap();
+    let args: Vec<S> = args.collect();
+    let args: Vec<String> = repair_params(args.iter());
+
+    let result = || {
+        let (cmd, mut payload) = prepare_parse_payload(&args)?;
+
+        let (cmd, cmd_params) = match parse_command(cmd, &mut payload) {
+            Ok((_, CommandParams::Special)) => {
+                return Ok(CassandraStressParsingResult::SpecialCommand)
+            }
+            Ok((cmd, params)) => (cmd, params),
+            Err(e) => return Err(e),
+        };
+
+        // TODO: parse options.
+
+        Ok(CassandraStressParsingResult::Workload(Box::new(
+            CassandraStressSettings::new(cmd, cmd_params),
+        )))
+    };
+
+    match result() {
+        Ok(v) => Ok(v),
+        Err(e) => {
+            print_help();
+            Err(e)
+        }
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
@@ -1,0 +1,55 @@
+use std::{cell::RefCell, rc::Rc};
+
+mod parser;
+mod simple_param;
+use regex::Regex;
+
+pub use parser::ParamsParser;
+pub use simple_param::SimpleParamHandle;
+
+fn regex_is_empty(regex: &Regex) -> bool {
+    regex.as_str() == "^$"
+}
+
+/// An 'interface' of parameter.
+///
+/// Note that the parser uses trait objects.
+/// For now, it may seem to be unnecessary since we only support `SimpleParam`s.
+/// However, cassandra-stress supports more complex parameters (see help -schema)
+/// which cql-stress should support in the future as well.
+pub trait Param {
+    /// Checks whether `arg` matches parameter's prefix.
+    /// Returns:
+    /// - ParamMatchResult::NoMatch if argument doesn't match the prefix
+    /// - ParamMatchResult::Error if argument matches the prefix, but doesn't satisfy the value pattern
+    /// - ParamMatchResult::Match if argument matches both prefix and value pattern.
+    fn try_match(&self, arg: &str) -> ParamMatchResult;
+    /// Sets the parameter's value to `arg`. Will panic if `try_match` doesn't return ParamMatchResult::Match.
+    fn parse(&mut self, arg: &str);
+    /// Tells whether the parameter was parsed with the user-provided argument.
+    fn supplied_by_user(&self) -> bool;
+    fn required(&self) -> bool;
+    /// Ref: check `ParamsGroup`.
+    /// Checking whether the group is satisfied happens right after all of the
+    /// CLI arguments were successfully consumed. If the group is satisfied,
+    /// it will mark all of its parameters as satisfied as well.
+    /// Then, before returning any value, the parameter will check if its satisfied.
+    /// If it's not, it will return `None`. Note that it's needed in case of parameters
+    /// with default values that don't belong to the satisfied group - otherwise, they would return `Some(_)`.
+    fn set_satisfied(&mut self);
+    /// Prints the usage format of the parameter.
+    fn print_usage(&self);
+    /// Prints short description of the parameter.
+    fn print_desc(&self);
+}
+
+type ParamCell = Rc<RefCell<dyn Param>>;
+
+pub trait ParamHandle {
+    fn cell(&self) -> ParamCell;
+}
+pub enum ParamMatchResult {
+    Match,
+    NoMatch,
+    Error(anyhow::Error),
+}

--- a/src/bin/cql-stress-cassandra-stress/settings/param/parser.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/parser.rs
@@ -1,0 +1,241 @@
+use anyhow::Result;
+use std::{cell::RefCell, rc::Rc};
+
+use super::{
+    simple_param::{SimpleParam, SimpleParamHandle},
+    ParamCell, ParamHandle, ParamMatchResult,
+};
+
+/// Some of the parameters are mutually exclusive. For example, we can't do
+/// `./cassandra-stress read n=10 n<20`.
+/// That's why we arrange the parameters in so called groups.
+///
+/// Given the output of `./cassandra-stress help read`:
+///
+/// Usage: read [err<?] [n>?] [n<?] [no-warmup] [truncate=?] [cl=?] [serial-cl=?]
+///  OR
+/// Usage: read n=? [no-warmup] [truncate=?] [cl=?] [serial-cl=?]
+///  OR
+/// Usage: read duration=? [no-warmup] [truncate=?] [cl=?] [serial-cl=?]
+///
+/// We see that there are 3 groups of the parameters - a group can be identified on whether
+/// `n=` or `duration=` parameter has been defined.
+struct ParamsGroup {
+    params: Vec<ParamCell>,
+}
+
+impl ParamsGroup {
+    fn new(params: Vec<ParamCell>) -> Self {
+        Self { params }
+    }
+
+    /// Tells whether the group is satisfied with received arguments.
+    /// The group is satisfied \iff all of the following requirements are satisfied:
+    ///   - number of consumed parameters by the group is equal to the number of CLI arguments
+    ///   - every required parameter has been provided by the user
+    fn satisfied(&self, args_size: usize) -> bool {
+        let consumed_count = self
+            .params
+            .iter()
+            .filter(|p| p.borrow().supplied_by_user())
+            .count();
+        if consumed_count != args_size {
+            return false;
+        }
+        if self
+            .params
+            .iter()
+            .any(|param| param.borrow().required() && !param.borrow().supplied_by_user())
+        {
+            return false;
+        }
+        true
+    }
+
+    fn mark_params_as_satisfied(&self) {
+        // The group is satisfied - it means that the parameters of this group
+        // were successfully parsed and will be returned to the user.
+        for param in self.params.iter() {
+            param.borrow_mut().set_satisfied();
+        }
+    }
+
+    fn print_help(&self) {
+        let params_size = self.params.len();
+        for (i, param) in self.params.iter().enumerate() {
+            param.borrow().print_usage();
+            if i < params_size - 1 {
+                print!(" ");
+            }
+        }
+    }
+}
+
+/// Parser lets the user define the parameters (see trait [`Param`]).
+/// The parser registers such parameter internally and returns the handle to the user.
+/// Once the user calls `Parser::parse` (which consumes the parser), the values of
+/// the parsed parameters can be retrieved using previously created handles.
+pub struct ParamsParser {
+    command_name: String,
+    params: Vec<ParamCell>,
+    groups: Vec<ParamsGroup>,
+}
+
+impl ParamsParser {
+    pub fn new(command_name: &str) -> Self {
+        Self {
+            command_name: command_name.to_owned(),
+            params: Vec::new(),
+            groups: Vec::new(),
+        }
+    }
+
+    /// Registers the simple parameter provided by the user and returns the handle.
+    /// `value_pattern` has to be a regular expression, otherwise we panic.
+    pub fn simple_param(
+        &mut self,
+        prefix: &'static str,
+        value_pattern: &'static str,
+        default: Option<&'static str>,
+        desc: &'static str,
+        required: bool,
+    ) -> SimpleParamHandle {
+        let param = Rc::new(RefCell::new(SimpleParam::new(
+            prefix,
+            value_pattern,
+            default,
+            desc,
+            required,
+        )));
+
+        self.params.push(Rc::clone(&param) as ParamCell);
+        SimpleParamHandle::new(param)
+    }
+
+    /// Creates a new group of the parameters.
+    pub fn group(&mut self, params: Vec<&dyn ParamHandle>) {
+        self.groups.push(ParamsGroup::new(
+            params.into_iter().map(|handle| handle.cell()).collect(),
+        ))
+    }
+
+    // Consume the parser during parsing.
+    pub fn parse(mut self, args: Vec<&str>) -> Result<()> {
+        if self.groups.is_empty() {
+            // User didn't specify any groups. Treat all parameters as a single group.
+            self.groups.push(ParamsGroup::new(self.params.clone()));
+        }
+
+        let args_size = args.len();
+        for arg in args {
+            let mut consumed = false;
+            for param in self.params.iter() {
+                let mut borrowed = param.borrow_mut();
+                match borrowed.try_match(arg) {
+                    ParamMatchResult::Error(e) => return Err(e),
+                    ParamMatchResult::NoMatch => (),
+                    ParamMatchResult::Match => {
+                        borrowed.parse(arg);
+                        consumed = true;
+                        break;
+                    }
+                }
+            }
+
+            anyhow::ensure!(consumed, "Invalid parameter {}", arg);
+        }
+
+        // Find satisfied group. If found, mark its parameters as satisfied as well.
+        if let Some(satisfied_group) = self.groups.iter().find(|g| g.satisfied(args_size)) {
+            satisfied_group.mark_params_as_satisfied();
+            return Ok(());
+        }
+
+        Err(anyhow::anyhow!(
+            "Invalid {} parameters provided, see `help {}` for valid parameters",
+            self.command_name.to_uppercase(),
+            self.command_name
+        ))
+    }
+
+    pub fn print_help(&self) {
+        let groups_size = self.groups.len();
+        println!();
+        for (i, group) in self.groups.iter().enumerate() {
+            print!("Usage: {} ", self.command_name);
+            group.print_help();
+            if i < groups_size - 1 {
+                print!("\n OR");
+            }
+            println!();
+        }
+        println!();
+
+        for param in self.params.iter() {
+            print!("  ");
+            param.borrow().print_desc();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::settings::param::SimpleParamHandle;
+
+    use super::ParamsParser;
+
+    fn prepare_parser() -> (
+        ParamsParser,
+        (SimpleParamHandle, SimpleParamHandle, SimpleParamHandle),
+    ) {
+        // Create a parser.
+        let mut parser = ParamsParser::new("some_parser");
+
+        // Define 3 parameters and get their corresponding handles.
+        let count = parser.simple_param("count=", r"^[0-9]+$", None, "this is count", true);
+
+        // Parameters with empty value_pattern (regex) are boolean flags.
+        let foo = parser.simple_param("foo", r"^$", None, "this is foo", false);
+        let duration = parser.simple_param(
+            "duration=",
+            r"^[0-9]+[smh]$",
+            Some("10s"),
+            "this is duration",
+            false,
+        );
+
+        // Group the parameters. Meaning that if a user defined,
+        // for example `count=` and `duration=` at the same time, the parsing should fail.
+        parser.group(vec![&count, &foo]);
+        parser.group(vec![&duration]);
+
+        (parser, (count, foo, duration))
+    }
+
+    #[test]
+    fn parser_success_test() {
+        let args = vec!["count=100", "foo"];
+        let (parser, (count, foo, duration)) = prepare_parser();
+
+        assert!(parser.parse(args).is_ok());
+
+        // We can now retrieve the parsed values from the handles.
+        assert_eq!(Some(100), count.get_type::<u64>());
+        assert!(foo.supplied_by_user());
+
+        // Even though `duration` has some default value, it doesn't belong
+        // to the same group as `count`. This is why we get `None`.
+        assert_eq!(None, duration.get());
+    }
+
+    #[test]
+    fn parser_fail_test() {
+        let args = vec!["count=100", "duration=20s"];
+
+        // We discard the handles, since the parsing will fail anyway.
+        let (parser, _) = prepare_parser();
+
+        // It fails because `count` and `duration` are from different groups.
+        assert!(parser.parse(args).is_err());
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/settings/param/simple_param.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/simple_param.rs
@@ -1,0 +1,168 @@
+use std::{cell::RefCell, fmt, rc::Rc, str::FromStr};
+
+use regex::Regex;
+
+use super::{regex_is_empty, Param, ParamCell, ParamHandle, ParamMatchResult};
+
+/// Abstraction of simple parameter which is of the following pattern:
+/// <prefix><value_pattern>
+///
+/// For example `n=` is a simple parameter where
+/// - prefix := "n="
+/// - value_pattern := r"^[0-9]+[bmk]?$"
+pub struct SimpleParam {
+    value: Option<String>,
+    prefix: &'static str,
+    value_pattern: Regex,
+    default: Option<&'static str>,
+    desc: &'static str,
+    required: bool,
+    supplied_by_user: bool,
+    satisfied: bool,
+}
+
+impl SimpleParam {
+    pub fn new(
+        prefix: &'static str,
+        value_pattern: &'static str,
+        default: Option<&'static str>,
+        desc: &'static str,
+        required: bool,
+    ) -> Self {
+        Self {
+            value: default.map(|d| d.to_string()),
+            prefix,
+            value_pattern: Regex::new(value_pattern).unwrap(),
+            default,
+            desc,
+            required,
+            supplied_by_user: false,
+            satisfied: false,
+        }
+    }
+
+    /// Retrieves the value (if parsed successfully) and consumes the parameter.
+    fn get(self) -> Option<String> {
+        if !self.satisfied {
+            return None;
+        }
+        self.value
+    }
+
+    fn is_bool_flag(&self) -> bool {
+        regex_is_empty(&self.value_pattern)
+    }
+}
+
+impl Param for SimpleParam {
+    fn try_match(&self, arg: &str) -> ParamMatchResult {
+        if !arg.starts_with(self.prefix) {
+            return ParamMatchResult::NoMatch;
+        }
+
+        if self.supplied_by_user {
+            return ParamMatchResult::Error(anyhow::anyhow!(
+                "{} suboption has been specified more than once",
+                self.prefix
+            ));
+        }
+
+        let arg_val = &arg[self.prefix.len()..];
+        if self.value_pattern.is_match(arg_val) {
+            return ParamMatchResult::Match;
+        }
+
+        ParamMatchResult::Error(anyhow::anyhow!(
+            "Invalid value {}; must patch pattern {}",
+            arg_val,
+            self.value_pattern.as_str()
+        ))
+    }
+
+    fn parse(&mut self, arg: &str) {
+        match self.try_match(arg) {
+            ParamMatchResult::Match => {
+                let arg_val = &arg[self.prefix.len()..];
+                self.supplied_by_user = true;
+                self.value = Some(arg_val.to_string());
+            }
+            _ => panic!("Cannot parse the parameter: {} with argument: {}. Make sure that Param::is_match returns `Match` before calling this method.", self.prefix, arg),
+        }
+    }
+
+    fn supplied_by_user(&self) -> bool {
+        self.supplied_by_user
+    }
+
+    fn required(&self) -> bool {
+        self.required
+    }
+
+    fn set_satisfied(&mut self) {
+        self.satisfied = true;
+    }
+
+    fn print_usage(&self) {
+        if !self.required {
+            print!("[");
+        }
+        print!("{}", self.prefix);
+        if !self.is_bool_flag() {
+            print!("?");
+        }
+        if !self.required {
+            print!("]");
+        }
+    }
+
+    fn print_desc(&self) {
+        let mut desc = String::from(self.prefix);
+        if !self.is_bool_flag() {
+            desc.push('?');
+        }
+        if let Some(default) = self.default {
+            desc += &format!(" (default={default})");
+        }
+        println!("{:<40} {}", desc, self.desc);
+    }
+}
+
+pub struct SimpleParamHandle {
+    cell: Rc<RefCell<SimpleParam>>,
+}
+
+impl SimpleParamHandle {
+    pub fn new(cell: Rc<RefCell<SimpleParam>>) -> Self {
+        Self { cell }
+    }
+
+    /// Retrieves the value from underlying parameter.
+    /// Consumes both handle and underlying parameter.
+    pub fn get(self) -> Option<String> {
+        let param_name = self.cell.borrow().prefix;
+        match Rc::try_unwrap(self.cell) {
+            Ok(cell) => cell.into_inner().get(),
+            Err(_) => panic!("Something holds the reference to `{param_name}` param cell. Make sure the parser is consumed with Parser::parse before calling this method."),
+        }
+    }
+
+    /// Parses the param's String value to type T.
+    /// Can cause panic.
+    pub fn get_type<T>(self) -> Option<T>
+    where
+        T: FromStr,
+        <T as FromStr>::Err: fmt::Debug,
+    {
+        self.get().map(|v| v.parse::<T>().unwrap())
+    }
+
+    pub fn supplied_by_user(&self) -> bool {
+        self.cell.borrow().supplied_by_user()
+    }
+}
+
+impl ParamHandle for SimpleParamHandle {
+    fn cell(&self) -> ParamCell {
+        Rc::clone(&self.cell) as ParamCell
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/settings/test.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/test.rs
@@ -1,0 +1,71 @@
+use super::{parse_cassandra_stress_args, repair_params};
+
+const DATA_GOOD: &str = include_str!("cs_args_good_test.in");
+const DATA_BAD: &str = include_str!("cs_args_bad_test.in");
+
+#[test]
+fn cs_args_good_test() {
+    let mut success: u32 = 0;
+    let mut failure: u32 = 0;
+
+    for (i, input) in DATA_GOOD.lines().enumerate() {
+        let input = input.trim();
+        if input.is_empty() || input.starts_with('#') {
+            continue;
+        }
+        match parse_cassandra_stress_args(input.to_lowercase().split_ascii_whitespace()) {
+            Err(_) => {
+                eprintln!("Error on line {}: {}", i + 1, input);
+                failure += 1;
+            }
+            _ => success += 1,
+        }
+
+        println!("Success count: {}, Failure count: {}", success, failure);
+        assert_eq!(failure, 0);
+    }
+}
+
+#[test]
+fn cs_args_bad_test() {
+    let mut success: u32 = 0;
+    let mut failure: u32 = 0;
+
+    for (i, input) in DATA_BAD.lines().enumerate() {
+        let input = input.trim();
+        if input.is_empty() || input.starts_with('#') {
+            continue;
+        }
+        match parse_cassandra_stress_args(input.to_lowercase().split_ascii_whitespace()) {
+            Err(_) => failure += 1,
+            _ => {
+                eprintln!("Should have failed on line {}: {}", i + 1, input);
+                success += 1;
+            }
+        }
+
+        println!("Success count: {}, Failure count: {}", success, failure);
+        assert_eq!(success, 0);
+    }
+}
+
+#[test]
+fn repair_params_test() {
+    let args = vec![
+        "write",
+        "-schema replication ( factor = 3 , foo = bar )\t \tkeyspace=k ",
+        " compression = someCompressionAlgorithm",
+    ];
+
+    let result = repair_params(args.iter());
+    assert_eq!(
+        vec![
+            "write",
+            "-schema",
+            "replication(factor=3,foo=bar)",
+            "keyspace=k",
+            "compression=someCompressionAlgorithm"
+        ],
+        result
+    );
+}


### PR DESCRIPTION
cassandra-stress accepts the CLI arguments of the following form:
`./cassandra-stress COMMAND [command_params...] [OPTION [option_params...] ...]`

An example:
`./cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1) -mode cql3 native -rate threads=10`

In this case the command is `read` and its parameters are `cl=` and `n=`.
Apart from the command, there are three options:
* -schema with `replication` parameter
* -mode with `cql3` and `native` parameters
* -rate with a single `threads=` parameter

Introduced corresponding modules:
* `settings` - Entry for CLI arguments parsing.
* `settings::param` - Contains the parameter abstraction and exposes parameters' parser API to the users (see `settings::command`).
* `settings::command` - Parses command and its parameters

Currently, only some subset of commands is supported. No options are supported yet.

Supported commands:
* help
* read
* write
* counter_write
* counter_read

It means that, going back to the example, with this commit cassandra-stress frontend is able to parse only part of the arguments - specifically: `./cassandra-stress read cl=QUORUM n=10000`.
Note that these are not the only available `read` command parameters.