### PR TITLE
c-s CLI: Options parsing

### DIFF
--- a/src/bin/cql-stress-cassandra-stress/settings/command/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/mod.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use std::convert::AsRef;
 use std::str::FromStr;
 use strum::IntoEnumIterator;
@@ -101,7 +102,7 @@ pub fn parse_command(
     command_str: &str,
     cl_args: &mut ParsePayload,
 ) -> Result<(Command, CommandParams)> {
-    let command = Command::parse(command_str)?;
+    let command = Command::parse(command_str).context("No command specified")?;
     let params = command.parse_params(cl_args)?;
     Ok((command, params))
 }

--- a/src/bin/cql-stress-cassandra-stress/settings/command/read_write.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/read_write.rs
@@ -279,11 +279,9 @@ fn prepare_parser(cmd: &str) -> (ParamsParser, ReadWriteParamHandles) {
     // Usage: read n=? [no-warmup] [truncate=?] [cl=?] [serial-cl=?]
     //  OR
     // Usage: read duration=? [no-warmup] [truncate=?] [cl=?] [serial-cl=?]
-    parser.group(vec![
-        &err, &ngt, &nlt, &no_warmup, &truncate, &cl, &serial_cl,
-    ]);
-    parser.group(vec![&n, &no_warmup, &truncate, &cl, &serial_cl]);
-    parser.group(vec![&duration, &no_warmup, &truncate, &cl, &serial_cl]);
+    parser.group(&[&err, &ngt, &nlt, &no_warmup, &truncate, &cl, &serial_cl]);
+    parser.group(&[&n, &no_warmup, &truncate, &cl, &serial_cl]);
+    parser.group(&[&duration, &no_warmup, &truncate, &cl, &serial_cl]);
 
     (
         parser,

--- a/src/bin/cql-stress-cassandra-stress/settings/command/read_write.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/read_write.rs
@@ -303,7 +303,7 @@ fn parse_with_handles(handles: ReadWriteParamHandles) -> ReadWriteParams {
     let err = handles.err.get();
     let ngt = handles.ngt.get();
     let nlt = handles.nlt.get();
-    let no_warmup = handles.no_warmup.supplied_by_user();
+    let no_warmup = handles.no_warmup.get().is_some();
     let truncate = handles.truncate.get().unwrap();
     let consistency_level = handles.cl.get().unwrap();
     let serial_consistency_level = handles.serial_cl.get().unwrap();

--- a/src/bin/cql-stress-cassandra-stress/settings/cs_args_bad_test.in
+++ b/src/bin/cql-stress-cassandra-stress/settings/cs_args_bad_test.in
@@ -8,3 +8,10 @@ cassandra-stress counter_read duration=1hour
 cassandra-stress foo
 cassandra-stress help foo
 cassandra-stress write cl=local_one cl=quorum
+cassandra-stress write cl=quorum no-warmup -node 127.0.0.1,192.168.0.1,
+cassandra-stress write -rate fixed=10/s threads>=10
+cassandra-stress read -schema replication(factor=abc)
+cassandra-stress read -schema replication(factor==123)
+cassandra-stress read -schema replication(factor=1,=)
+cassandra-stress counter_write cl=QUORUM duration=20m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' no-warmup
+cassandra-stress write -rate keyspace=keyspace2

--- a/src/bin/cql-stress-cassandra-stress/settings/cs_args_good_test.in
+++ b/src/bin/cql-stress-cassandra-stress/settings/cs_args_good_test.in
@@ -10,3 +10,15 @@ cassandra-stress counter_read
 cassandra-stress counter_write
 cassandra-stress help
 cassandra-stress help read
+cassandra-stress read no-warmup cl=QUORUM duration=600m -rate threads=80 throttle=8000/s
+cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1) -rate threads=10
+cassandra-stress read cl=QUORUM n=10000 -schema replication(key=value) -rate threads=10
+cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1, key=value) -rate threads=10
+cassandra-stress read no-warmup cl=QUORUM n=10000 -schema keyspace=keyspace_new_dc compression=LZ4Compressor -rate threads=5
+cassandra-stress counter_write no-warmup cl=QUORUM duration=20m -schema replication(strategy=NetworkTopologyStrategy,replication_factor=3)
+cassandra-stress counter_write no-warmup cl=QUORUM duration=20m -schema replication(strategy=NetworkTopologyStrategy)
+cassandra-stress counter_write no-warmup cl=QUORUM duration=20m -schema replication(replication_factor=3)
+cassandra-stress counter_write no-warmup cl=LOCAL_ONE duration=20m -schema replication(strategy=NetworkTopologyStrategy,replication_factor=3) keyspace=keyspace2
+cassandra-stress counter_write no-warmup cl=THREE duration=20m -schema keyspace=keyspace2
+cassandra-stress counter_write no-warmup cl=ANY duration=20m -schema replication(strategy=NetworkTopologyStrategy) keyspace=keyspace2
+cassandra-stress counter_write no-warmup cl=ALL duration=20m -schema replication(replication_factor=3) keyspace=keyspace2

--- a/src/bin/cql-stress-cassandra-stress/settings/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/mod.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::iter::Iterator;
 
 mod command;
+mod option;
 mod param;
 use anyhow::Result;
 

--- a/src/bin/cql-stress-cassandra-stress/settings/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/mod.rs
@@ -16,20 +16,25 @@ use regex::Regex;
 use crate::settings::command::print_help;
 
 use self::command::parse_command;
+use self::option::NodeOption;
+use self::option::RateOption;
+use self::option::SchemaOption;
 
 pub struct CassandraStressSettings {
     pub command: Command,
     pub params: CommandParams,
+    pub node: NodeOption,
+    pub rate: RateOption,
+    pub schema: SchemaOption,
 }
 
 impl CassandraStressSettings {
-    fn new(command: Command, params: CommandParams) -> Self {
-        Self { command, params }
-    }
-
     pub fn print_settings(&self) {
         println!("******************** Stress Settings ********************");
         self.params.print_settings(&self.command);
+        self.rate.print_settings();
+        self.node.print_settings();
+        self.schema.print_settings();
         println!();
     }
 }
@@ -135,7 +140,7 @@ where
     let result = || {
         let (cmd, mut payload) = prepare_parse_payload(&args)?;
 
-        let (cmd, cmd_params) = match parse_command(cmd, &mut payload) {
+        let (command, params) = match parse_command(cmd, &mut payload) {
             Ok((_, CommandParams::Special)) => {
                 return Ok(CassandraStressParsingResult::SpecialCommand)
             }
@@ -143,10 +148,38 @@ where
             Err(e) => return Err(e),
         };
 
-        // TODO: parse options.
+        let node = NodeOption::parse(&mut payload)?;
+        let rate = RateOption::parse(&mut payload)?;
+        let schema = SchemaOption::parse(&mut payload)?;
+
+        // List the unknown options along with their parameters.
+        let build_unknown_arguments_err_message = || -> String {
+            let unknowns = payload
+                .iter()
+                .map(|(option, params)| {
+                    let params_str = params.join(" ");
+                    format!("{option} {params_str}")
+                })
+                .collect::<Vec<_>>();
+            unknowns.join("\n")
+        };
+
+        // Ensure that all of the CLI arguments were consumed.
+        // If not, then unknown arguments appeared so we return the error.
+        anyhow::ensure!(
+            payload.is_empty(),
+            "Error processing CLI arguments. The following were ignored:\n{}",
+            build_unknown_arguments_err_message()
+        );
 
         Ok(CassandraStressParsingResult::Workload(Box::new(
-            CassandraStressSettings::new(cmd, cmd_params),
+            CassandraStressSettings {
+                command,
+                params,
+                node,
+                rate,
+                schema,
+            },
         )))
     };
 

--- a/src/bin/cql-stress-cassandra-stress/settings/option/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/option/mod.rs
@@ -1,0 +1,24 @@
+use anyhow::Result;
+
+pub struct Options;
+
+impl Options {
+    fn help_messages() -> impl Iterator<Item = (&'static str, &'static str)> {
+        [].into_iter()
+    }
+
+    pub fn print_generic_help() {
+        println!("---Options---");
+        for (option, description) in Self::help_messages() {
+            println!("{:<20} : {}", option, description);
+        }
+    }
+
+    pub fn print_help(option_str: &str) -> Result<()> {
+        match option_str {
+            _ => return Err(anyhow::anyhow!("Invalid option provided to command help")),
+        }
+
+        Ok(())
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/settings/option/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/option/mod.rs
@@ -1,10 +1,14 @@
+mod node;
+
 use anyhow::Result;
+
+pub use node::NodeOption;
 
 pub struct Options;
 
 impl Options {
     fn help_messages() -> impl Iterator<Item = (&'static str, &'static str)> {
-        [].into_iter()
+        [(NodeOption::CLI_STRING, NodeOption::description())].into_iter()
     }
 
     pub fn print_generic_help() {
@@ -16,6 +20,7 @@ impl Options {
 
     pub fn print_help(option_str: &str) -> Result<()> {
         match option_str {
+            NodeOption::CLI_STRING => NodeOption::print_help(),
             _ => return Err(anyhow::anyhow!("Invalid option provided to command help")),
         }
 

--- a/src/bin/cql-stress-cassandra-stress/settings/option/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/option/mod.rs
@@ -1,10 +1,12 @@
 mod node;
 mod rate;
+mod schema;
 
 use anyhow::Result;
 
 pub use node::NodeOption;
 pub use rate::RateOption;
+pub use schema::SchemaOption;
 
 pub struct Options;
 
@@ -13,6 +15,7 @@ impl Options {
         [
             (NodeOption::CLI_STRING, NodeOption::description()),
             (RateOption::CLI_STRING, RateOption::description()),
+            (SchemaOption::CLI_STRING, SchemaOption::description()),
         ]
         .into_iter()
     }
@@ -28,6 +31,7 @@ impl Options {
         match option_str {
             NodeOption::CLI_STRING => NodeOption::print_help(),
             RateOption::CLI_STRING => RateOption::print_help(),
+            SchemaOption::CLI_STRING => SchemaOption::print_help(),
             _ => return Err(anyhow::anyhow!("Invalid option provided to command help")),
         }
 

--- a/src/bin/cql-stress-cassandra-stress/settings/option/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/option/mod.rs
@@ -1,14 +1,20 @@
 mod node;
+mod rate;
 
 use anyhow::Result;
 
 pub use node::NodeOption;
+pub use rate::RateOption;
 
 pub struct Options;
 
 impl Options {
     fn help_messages() -> impl Iterator<Item = (&'static str, &'static str)> {
-        [(NodeOption::CLI_STRING, NodeOption::description())].into_iter()
+        [
+            (NodeOption::CLI_STRING, NodeOption::description()),
+            (RateOption::CLI_STRING, RateOption::description()),
+        ]
+        .into_iter()
     }
 
     pub fn print_generic_help() {
@@ -21,6 +27,7 @@ impl Options {
     pub fn print_help(option_str: &str) -> Result<()> {
         match option_str {
             NodeOption::CLI_STRING => NodeOption::print_help(),
+            RateOption::CLI_STRING => RateOption::print_help(),
             _ => return Err(anyhow::anyhow!("Invalid option provided to command help")),
         }
 

--- a/src/bin/cql-stress-cassandra-stress/settings/option/node.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/option/node.rs
@@ -1,0 +1,152 @@
+use std::{
+    fs::File,
+    io::{self, BufRead},
+};
+
+use anyhow::{Context, Result};
+
+use crate::settings::{
+    param::{types::CommaDelimitedList, ParamsParser, SimpleParamHandle},
+    ParsePayload,
+};
+
+pub struct NodeOption {
+    pub nodes: Vec<String>,
+    pub whitelist: bool,
+    pub datacenter: Option<String>,
+}
+
+impl NodeOption {
+    pub const CLI_STRING: &str = "-node";
+
+    pub fn description() -> &'static str {
+        "Nodes to connect to"
+    }
+
+    pub fn parse(cl_args: &mut ParsePayload) -> Result<Self> {
+        let params = cl_args.remove(Self::CLI_STRING).unwrap_or_default();
+        let (parser, handles) = prepare_parser();
+        parser.parse(params)?;
+        Self::from_handles(handles)
+    }
+
+    pub fn print_help() {
+        let (parser, _) = prepare_parser();
+        parser.print_help();
+    }
+
+    pub fn print_settings(&self) {
+        println!("Node:");
+        println!("  Nodes: {:?}", self.nodes);
+        println!("  Is White List: {}", self.whitelist);
+        println!("  Datacenter: {:?}", self.datacenter);
+    }
+
+    fn from_handles(handles: NodeParamHandles) -> Result<NodeOption> {
+        let datacenter = handles.datacenter.get();
+        let whitelist = handles.whitelist.get().is_some();
+        let file = handles.file.get();
+        let nodes = handles.nodes.get();
+
+        let nodes = match nodes {
+            Some(nodes) => nodes,
+            // SAFETY: Parameters are grouped in a way that either `nodes` or `file` is Some.
+            // Note that it's never the case that both of them are Some.
+            _ => read_nodes_from_file(&file.unwrap())?,
+        };
+
+        Ok(Self {
+            nodes,
+            whitelist,
+            datacenter,
+        })
+    }
+}
+
+struct NodeParamHandles {
+    datacenter: SimpleParamHandle<String>,
+    whitelist: SimpleParamHandle<bool>,
+    file: SimpleParamHandle<String>,
+    nodes: SimpleParamHandle<CommaDelimitedList>,
+}
+
+fn prepare_parser() -> (ParamsParser, NodeParamHandles) {
+    let mut parser = ParamsParser::new(NodeOption::CLI_STRING);
+
+    let datacenter = parser.simple_param(
+        "datacenter=",
+        None,
+        "Preferred datacenter for the default load balancing policy",
+        false,
+    );
+    let whitelist = parser.simple_param(
+        "whitelist",
+        None,
+        "Limit communications to the provided nodes",
+        false,
+    );
+    let file = parser.simple_param("file=", None, "Node file (one per line)", false);
+    let nodes = parser.simple_param(
+        "",
+        Some("localhost"),
+        "comma delimited list of nodes",
+        false,
+    );
+
+    // $ ./cassandra-stress help -node
+    // Usage: -node [datacenter=?] [whitelist] []
+    //  OR
+    // Usage: -node [datacenter=?] [whitelist] [file=?]
+    parser.group(&[&datacenter, &whitelist, &nodes]);
+    parser.group(&[&datacenter, &whitelist, &file]);
+
+    (
+        parser,
+        NodeParamHandles {
+            datacenter,
+            whitelist,
+            file,
+            nodes,
+        },
+    )
+}
+
+fn read_nodes_from_file(filename: &str) -> Result<Vec<String>> {
+    let file = File::open(filename).context("Invalid nodes file")?;
+    let buf = io::BufReader::new(file);
+    buf.lines()
+        // Filter out empty lines.
+        .filter(|s| !s.as_ref().is_ok_and(String::is_empty))
+        .collect::<Result<Vec<_>, _>>()
+        .context("Invalid nodes file")
+}
+
+#[cfg(test)]
+mod tests {
+    use node::NodeOption;
+
+    use crate::settings::option::node;
+
+    use super::prepare_parser;
+
+    #[test]
+    fn node_good_params_test() {
+        let args = vec!["whitelist", "127.0.0.1,localhost,192.168.0.1"];
+        let (parser, handles) = prepare_parser();
+
+        assert!(parser.parse(args).is_ok());
+
+        let params = NodeOption::from_handles(handles).unwrap();
+        assert_eq!(None, params.datacenter);
+        assert!(params.whitelist);
+        assert_eq!(vec!["127.0.0.1", "localhost", "192.168.0.1"], params.nodes);
+    }
+
+    #[test]
+    fn node_bad_params_test() {
+        let args = vec!["whitelist", "127.0.0.1,localhost,192.168.0.1,"];
+        let (parser, _) = prepare_parser();
+
+        assert!(parser.parse(args).is_err());
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/settings/option/rate.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/option/rate.rs
@@ -1,0 +1,216 @@
+use crate::settings::{
+    param::{types::Rate, ParamsParser, SimpleParamHandle},
+    ParsePayload,
+};
+use anyhow::Result;
+
+pub struct RateOption {
+    threads_info: ThreadsInfo,
+}
+
+#[derive(PartialEq, Debug)]
+pub enum ThreadsInfo {
+    Fixed {
+        threads: u64,
+        throttle: Option<u64>,
+        co_fixed: bool,
+    },
+    Auto {
+        min_threads: u64,
+        max_threads: u64,
+        auto: bool,
+    },
+}
+
+impl ThreadsInfo {
+    fn print_settings(&self) {
+        match &self {
+            Self::Fixed {
+                threads,
+                throttle,
+                co_fixed,
+            } => {
+                println!("  Thread count: {}", threads);
+                if let Some(throttle) = throttle {
+                    println!("  OpsPer Sec: {}", throttle);
+                }
+                println!("  Coordinated-Omission-Fixed latencies: {}", co_fixed);
+            }
+            Self::Auto {
+                min_threads,
+                max_threads,
+                auto,
+            } => {
+                println!("  Min threads: {}", min_threads);
+                println!("  Max threads: {}", max_threads);
+                println!("  auto: {}", auto);
+            }
+        }
+    }
+}
+
+impl RateOption {
+    pub const CLI_STRING: &str = "-rate";
+
+    pub fn description() -> &'static str {
+        "Thread count, rate limit or automatic mode (default is auto)"
+    }
+
+    pub fn parse(cl_args: &mut ParsePayload) -> Result<Self> {
+        let params = cl_args.remove(Self::CLI_STRING).unwrap_or_default();
+        let (parser, handles) = prepare_parser();
+        parser.parse(params)?;
+        Self::from_handles(handles)
+    }
+
+    pub fn print_help() {
+        let (parser, _) = prepare_parser();
+        parser.print_help();
+    }
+
+    pub fn print_settings(&self) {
+        println!("Rate:");
+        self.threads_info.print_settings();
+    }
+
+    fn from_handles(handles: RateParamHandles) -> Result<Self> {
+        let threads = handles.threads.get();
+        let throttle = handles.throttle.get();
+        let co_fixed = handles.co_fixed.get().is_some();
+        let min_threads = handles.threads_gte.get();
+        let max_threads = handles.threads_lte.get();
+        let auto = handles.auto.get().is_some();
+
+        let threads_info = match (min_threads, max_threads) {
+            (Some(min_threads), Some(max_threads)) => ThreadsInfo::Auto {
+                min_threads,
+                max_threads,
+                auto,
+            },
+            _ => ThreadsInfo::Fixed {
+                // SAFETY: The parameters are grouped in a way that this won't ever panic
+                // when entering this branch.
+                threads: threads.unwrap(),
+                throttle,
+                co_fixed,
+            },
+        };
+
+        Ok(Self { threads_info })
+    }
+}
+
+struct RateParamHandles {
+    pub threads: SimpleParamHandle<u64>,
+    pub throttle: SimpleParamHandle<Rate>,
+    pub co_fixed: SimpleParamHandle<bool>,
+    pub threads_gte: SimpleParamHandle<u64>,
+    pub threads_lte: SimpleParamHandle<u64>,
+    pub auto: SimpleParamHandle<bool>,
+}
+
+fn prepare_parser() -> (ParamsParser, RateParamHandles) {
+    let mut parser = ParamsParser::new(RateOption::CLI_STRING);
+
+    let threads = parser.simple_param("threads=", None, "run this many clients concurrently", true);
+    let throttle = parser.simple_param(
+        "throttle=",
+        None,
+        "throttle operations per second across all clients to a maximum rate (or less) with no implied schedule",
+        false,
+    );
+    let co_fixed = parser.simple_param(
+        "fixed",
+        None,
+        "display coordinated-omission-fixed latencies",
+        false,
+    );
+    let threads_gte = parser.simple_param(
+        "threads>=",
+        Some("4"),
+        "run at least this many clients concurrently",
+        false,
+    );
+    let threads_lte = parser.simple_param(
+        "threads<=",
+        Some("1000"),
+        "run at most this many clients concurrently",
+        false,
+    );
+    let auto = parser.simple_param(
+        "auto",
+        None,
+        "stop increasing threads once throughput saturates",
+        false,
+    );
+
+    // $ ./cassandra-stress help -rate
+    // Usage: -rate threads=? [throttle=?] [fixed]
+    //  OR
+    // Usage: -rate [threads>=?] [threads<=?] [auto]
+    parser.group(&[&threads, &throttle, &co_fixed]);
+    parser.group(&[&threads_gte, &threads_lte, &auto]);
+
+    (
+        parser,
+        RateParamHandles {
+            threads,
+            throttle,
+            co_fixed,
+            threads_gte,
+            threads_lte,
+            auto,
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::settings::option::{rate::ThreadsInfo, RateOption};
+
+    use super::prepare_parser;
+
+    #[test]
+    fn rate_good_params_group_one_test() {
+        let args = vec!["threads=100", "throttle=15/s"];
+        let (parser, handles) = prepare_parser();
+
+        assert!(parser.parse(args).is_ok());
+
+        let params = RateOption::from_handles(handles).unwrap();
+        assert_eq!(
+            ThreadsInfo::Fixed {
+                threads: 100,
+                throttle: Some(15),
+                co_fixed: false
+            },
+            params.threads_info
+        );
+    }
+
+    #[test]
+    fn rate_good_params_group_two_test() {
+        let args = vec!["threads<=200", "auto"];
+        let (parser, handles) = prepare_parser();
+
+        assert!(parser.parse(args).is_ok());
+
+        let params = RateOption::from_handles(handles).unwrap();
+        assert_eq!(
+            ThreadsInfo::Auto {
+                min_threads: 4,
+                max_threads: 200,
+                auto: true
+            },
+            params.threads_info
+        )
+    }
+
+    #[test]
+    fn rate_bad_params_test() {
+        let args = vec!["threads<=200", "auto", "fixed=10/s"];
+        let (parser, _) = prepare_parser();
+
+        assert!(parser.parse(args).is_err());
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/settings/option/schema.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/option/schema.rs
@@ -1,0 +1,179 @@
+use crate::settings::{
+    param::{MultiParamAcceptsArbitraryHandle, ParamsParser, SimpleParamHandle},
+    ParsePayload,
+};
+use anyhow::Result;
+use std::collections::HashMap;
+
+pub struct SchemaOption {
+    pub replication_factor: u64,
+    pub replication_strategy: String,
+    pub replication_opts: HashMap<String, String>,
+    pub keyspace: String,
+    pub compaction_strategy: Option<String>,
+    pub compaction_opts: HashMap<String, String>,
+    pub compression: Option<String>,
+}
+
+impl SchemaOption {
+    pub fn description() -> &'static str {
+        "Replication settings, compression, compaction, etc."
+    }
+
+    pub const CLI_STRING: &str = "-schema";
+
+    pub fn parse(cl_args: &mut ParsePayload) -> Result<Self> {
+        let params = cl_args.remove(Self::CLI_STRING).unwrap_or_default();
+        let (parser, handles) = prepare_parser();
+        parser.parse(params)?;
+        Ok(Self::from_handles(handles))
+    }
+
+    pub fn print_help() {
+        let (parser, _) = prepare_parser();
+        parser.print_help();
+    }
+
+    pub fn print_settings(&self) {
+        println!("Schema:");
+        println!("  Keyspace: {}", self.keyspace);
+        println!("  Replication Factor: {}", self.replication_factor);
+        println!("  Replication Strategy: {}", self.replication_strategy);
+        println!(
+            "  Replication Strategy Options: {:?}",
+            self.replication_opts
+        );
+        println!("  Table Compression: {:?}", self.compression);
+        println!(
+            "  Table Compaction Strategy: {:?}",
+            self.compaction_strategy
+        );
+        println!("  Table Compaction Options: {:?}", self.compaction_opts);
+    }
+
+    fn from_handles(handles: SchemaParamHandles) -> Self {
+        let replication_strategy = handles.replication_strategy.get().unwrap();
+        let replication_factor = handles.replication_factor.get().unwrap();
+        let replication_opts = handles.replication_opts.get_arbitrary().unwrap();
+        let keyspace = handles.keyspace.get().unwrap();
+        let compaction_strategy = handles.compaction_strategy.get();
+        let compaction_opts = handles.compaction_opts.get_arbitrary().unwrap();
+        let compression = handles.compression.get();
+
+        Self {
+            replication_factor,
+            replication_strategy,
+            replication_opts,
+            keyspace,
+            compaction_strategy,
+            compaction_opts,
+            compression,
+        }
+    }
+}
+
+struct SchemaParamHandles {
+    replication_factor: SimpleParamHandle<u64>,
+    replication_strategy: SimpleParamHandle<String>,
+    replication_opts: MultiParamAcceptsArbitraryHandle,
+    keyspace: SimpleParamHandle<String>,
+    compaction_strategy: SimpleParamHandle<String>,
+    compaction_opts: MultiParamAcceptsArbitraryHandle,
+    compression: SimpleParamHandle<String>,
+}
+
+fn prepare_parser() -> (ParamsParser, SchemaParamHandles) {
+    let mut parser = ParamsParser::new(SchemaOption::CLI_STRING);
+
+    let replication_strategy = parser.simple_subparam(
+        "strategy=",
+        Some("SimpleStrategy"),
+        "The replication strategy to use",
+        false,
+    );
+    let replication_factor =
+        parser.simple_subparam("factor=", Some("1"), "The number of replicas", false);
+    // Multiparameter with two predefined parameters: `strategy` and `factor`.
+    let replication = parser.multi_param(
+        "replication",
+        &[&replication_strategy, &replication_factor],
+        "Define the replication strategy and any parameters",
+        false,
+    );
+    let keyspace = parser.simple_param(
+        "keyspace=",
+        Some("keyspace1"),
+        "The keyspace name to use",
+        false,
+    );
+    let compaction_strategy =
+        parser.simple_subparam("strategy=", None, "The compaction strategy to use", false);
+    let compaction = parser.multi_param(
+        "compaction",
+        &[&compaction_strategy],
+        "Define the compaction strategy and any parameters",
+        false,
+    );
+    let compression = parser.simple_param(
+        "compression=",
+        None,
+        "Specify the compression to use for sstable, default:no compression",
+        false,
+    );
+
+    // $ ./cassandra-stress help -schema
+    // Usage: -schema [replication(?)] [keyspace=?] [compaction(?)] [compression=?]
+    parser.group(&[&replication, &keyspace, &compaction, &compression]);
+
+    (
+        parser,
+        SchemaParamHandles {
+            replication_factor,
+            replication_strategy,
+            replication_opts: replication,
+            keyspace,
+            compaction_strategy,
+            compaction_opts: compaction,
+            compression,
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{prepare_parser, SchemaOption};
+
+    #[test]
+    fn schema_param_good_test() {
+        let args = vec![
+            "replication(factor=3,key1=value1,strategy=MyStrategy,key2=value2)",
+            "keyspace=my_keyspace",
+            "compaction(key1=value1)",
+        ];
+
+        let (parser, handles) = prepare_parser();
+        assert!(parser.parse(args).is_ok());
+
+        let params = SchemaOption::from_handles(handles);
+
+        assert_eq!(3, params.replication_factor);
+        assert_eq!("MyStrategy", params.replication_strategy);
+        assert_eq!(2, params.replication_opts.len());
+        assert_eq!(
+            Some("value1"),
+            params.replication_opts.get("key1").map(String::as_str)
+        );
+        assert_eq!(
+            Some("value2"),
+            params.replication_opts.get("key2").map(String::as_str)
+        );
+        assert_eq!("my_keyspace", params.keyspace);
+        assert_eq!(None, params.compaction_strategy);
+        assert_eq!(1, params.compaction_opts.len());
+        assert_eq!(
+            Some("value1"),
+            params.compaction_opts.get("key1").map(String::as_str)
+        );
+        assert_eq!(None, params.compression);
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
@@ -7,6 +7,7 @@ pub mod types;
 
 use anyhow::Result;
 
+pub use multi_param::MultiParamAcceptsArbitraryHandle;
 pub use multi_param::MultiParamHandle;
 pub use parser::ParamsParser;
 pub use simple_param::SimpleParamHandle;

--- a/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
@@ -1,5 +1,6 @@
 use std::{cell::RefCell, rc::Rc};
 
+mod multi_param;
 mod parser;
 mod simple_param;
 pub mod types;

--- a/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
@@ -7,6 +7,7 @@ pub mod types;
 
 use anyhow::Result;
 
+pub use multi_param::MultiParamHandle;
 pub use parser::ParamsParser;
 pub use simple_param::SimpleParamHandle;
 

--- a/src/bin/cql-stress-cassandra-stress/settings/param/multi_param.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/multi_param.rs
@@ -1,0 +1,305 @@
+use std::{cell::RefCell, collections::HashMap, rc::Rc};
+
+use anyhow::Result;
+use regex::Regex;
+
+use super::{Param, ParamCell, ParamHandle, ParamMatchResult};
+
+lazy_static! {
+    // The arbitrary parameters should match pattern `key=value`.
+    static ref ARBITRARY_PARAM: Regex = Regex::new(r"^([^=]+)=([^=]+)$").unwrap();
+}
+
+/// Multiparameters may or may not accept arbitrary parameters.
+/// That's why we introduce the trait responsible for accepting such parameters.
+/// [MultiParam] is generic over the types that implement this trait.
+/// See [AcceptsArbitraryParams] and [RejectsArbitraryParams].
+pub trait ArbitraryParamsAcceptance: Sized + Default {
+    fn accepts_arbitrary(&self) -> bool;
+    fn try_parse_arbitrary(&mut self, param_name: &str, arg: &str) -> Result<()>;
+}
+
+/// [MultiParam<AcceptsArbitraryParams>] will accept all of the arbitrary parameters.
+#[derive(Default)]
+pub struct AcceptsArbitraryParams {
+    map: HashMap<String, String>,
+}
+
+impl ArbitraryParamsAcceptance for AcceptsArbitraryParams {
+    fn accepts_arbitrary(&self) -> bool {
+        true
+    }
+
+    fn try_parse_arbitrary(&mut self, param_name: &str, arg: &str) -> Result<()> {
+        // Ensure that argument matches pattern "key=value"
+        anyhow::ensure!(
+            ARBITRARY_PARAM.is_match(arg),
+            "Invalid '{}' specification: '{}'",
+            param_name,
+            arg
+        );
+
+        let (key, val) = {
+            let mut split = arg.split('=');
+            let key = split.next();
+            let val = split.next();
+            match (key, val, split.next()) {
+                (Some(key), Some(val), None) => (key, val),
+                _ => anyhow::bail!("Invalid arbitrary parameter: {}", arg),
+            }
+        };
+
+        anyhow::ensure!(
+            !self.map.contains_key(key),
+            "{} suboption has been specified more than once",
+            key
+        );
+        self.map.insert(key.to_owned(), val.to_owned());
+
+        Ok(())
+    }
+}
+
+/// [MultiParam<RejectsArbitraryParams>] rejects all arbitrary params by returning an error.
+#[derive(Default)]
+pub struct RejectsArbitraryParams;
+
+impl ArbitraryParamsAcceptance for RejectsArbitraryParams {
+    fn accepts_arbitrary(&self) -> bool {
+        false
+    }
+
+    fn try_parse_arbitrary(&mut self, param_name: &str, arg: &str) -> Result<()> {
+        Err(anyhow::anyhow!(
+            "Cannot accept parameter {}. {} command/option doesn't accept arbitrary parameters.",
+            arg,
+            param_name
+        ))
+    }
+}
+
+/// Representation of complex parameter - so called multiparameters.
+/// Multiparams have some predefined subparameters (subparams field)
+/// as well as (if applicable) arbitrary parameters (arbitrary_params field).
+///
+/// For example take `replication` parameter of `-schema` option:
+/// The help message produces:
+///
+/// replication([strategy=?][factor=?][<option 1..N>=?]): Define the replication strategy and any parameters
+///    strategy=? (default=org.apache.cassandra.locator.SimpleStrategy) The replication strategy to use
+///    factor=? (default=1)                     The number of replicas
+///
+/// So in this case replication parameter accepts two (non-required) predefined parameters: `strategy` and `factor`.
+/// It also accepts arbitrary parameters (denoted by `[<option 1..N>=?]`).
+///
+/// This means that parser should accept an exemplary input:
+/// replication(foo=bar,factor=3,key=value)
+///
+/// The multiparameter will delegate parsing of `factor=3` part to its predefined subparameter.
+/// `foo=bar` and `key=value` will be stored in the map of arbitrary parameters.
+pub struct MultiParam<A: ArbitraryParamsAcceptance> {
+    prefix: &'static str,
+    // Pre-defined parameters.
+    // User can access them via their corresponding handles.
+    subparams: Vec<ParamCell>,
+    desc: &'static str,
+    required: bool,
+    // Arbitrary parameters of the `key=value` form.
+    arbitrary_params: A,
+    supplied_by_user: bool,
+    satisfied: bool,
+}
+
+impl MultiParam<AcceptsArbitraryParams> {
+    /// Retrieves arbitrary subparameters (if parsed successfully) and consumes the parameter.
+    pub fn get_arbitrary(self) -> Option<HashMap<String, String>> {
+        self.satisfied.then_some(self.arbitrary_params.map)
+    }
+}
+
+impl<A: ArbitraryParamsAcceptance> MultiParam<A> {
+    pub fn new(
+        prefix: &'static str,
+        subparams: Vec<ParamCell>,
+        desc: &'static str,
+        required: bool,
+    ) -> Self {
+        Self {
+            prefix,
+            subparams,
+            desc,
+            required,
+            arbitrary_params: Default::default(),
+            supplied_by_user: false,
+            satisfied: false,
+        }
+    }
+
+    fn accepts_arbitrary(&self) -> bool {
+        self.arbitrary_params.accepts_arbitrary()
+    }
+
+    fn try_parse_predefined(&self, arg: &str) -> ParamMatchResult {
+        for param in self.subparams.iter() {
+            let mut borrowed = param.borrow_mut();
+            match borrowed.try_match(arg) {
+                ParamMatchResult::NoMatch => (),
+                e @ ParamMatchResult::Error(_) => return e,
+                ParamMatchResult::Match => match borrowed.parse(arg) {
+                    Ok(()) => return ParamMatchResult::Match,
+                    Err(e) => return ParamMatchResult::Error(e),
+                },
+            }
+        }
+
+        ParamMatchResult::NoMatch
+    }
+}
+
+impl<A: ArbitraryParamsAcceptance> Param for MultiParam<A> {
+    fn parse(&mut self, arg: &str) -> Result<()> {
+        self.supplied_by_user = true;
+        let arg_val = &arg[self.prefix.len()..];
+
+        // Remove wrapping parenthesis.
+        let arg_val = {
+            let mut chars = arg_val.chars();
+            chars.next();
+            chars.next_back();
+            chars.as_str()
+        };
+
+        // Iterate over comma-delimited sub-parameters.
+        for subparam in arg_val.split(',') {
+            // Check if the argument matches on of the predefined subparameters.
+            match self.try_parse_predefined(subparam) {
+                ParamMatchResult::Error(e) => return Err(e),
+                ParamMatchResult::Match => continue,
+                _ => (),
+            }
+
+            // If the argument didn't match any of the prefefined sub-parameters,
+            // try to parse it as an arbitrary parameter (if applicable).
+            self.arbitrary_params
+                .try_parse_arbitrary(self.prefix, subparam)?;
+        }
+
+        Ok(())
+    }
+
+    fn supplied_by_user(&self) -> bool {
+        self.supplied_by_user
+    }
+
+    fn required(&self) -> bool {
+        self.required
+    }
+
+    fn set_satisfied(&mut self) {
+        self.satisfied = true;
+        for param in self.subparams.iter() {
+            param.borrow_mut().set_satisfied();
+        }
+
+        // Clear the subparameters so the user can consume them via corresponding handles.
+        // Otherwise, retrieving the value by the user would cause panic.
+        // Note that SimpleParamHandle::get(), as well as MultiParamHandle::get_arbitrary()
+        // use [std::cell::RefCell::try_unwrap] method (and panic on error), since these methods
+        // consume both - the handle and the parameter referenced by the handle.
+        self.subparams.clear();
+    }
+
+    fn print_usage(&self) {
+        print!("[{}(?)]", self.prefix)
+    }
+
+    fn print_desc(&self) {
+        print!("{}(", self.prefix);
+        for param in self.subparams.iter() {
+            param.borrow().print_usage();
+        }
+        if self.accepts_arbitrary() {
+            print!("[<option 1..N>=?]");
+        }
+        println!("): {}", self.desc);
+        for param in self.subparams.iter() {
+            print!("      ");
+            param.borrow().print_desc();
+        }
+    }
+
+    fn try_match(&self, arg: &str) -> ParamMatchResult {
+        if !arg.starts_with(self.prefix) {
+            return ParamMatchResult::NoMatch;
+        }
+
+        if self.supplied_by_user {
+            return ParamMatchResult::Error(anyhow::anyhow!(
+                "{} suboption has been specified more than once",
+                self.prefix
+            ));
+        }
+
+        let arg_val = &arg[self.prefix.len()..];
+        if !arg_val.starts_with('(') || !arg_val.ends_with(')') {
+            return ParamMatchResult::Error(anyhow::anyhow!(
+                "Invalid {} specification: {}",
+                self.prefix,
+                arg
+            ));
+        }
+        ParamMatchResult::Match
+    }
+}
+
+type MultiParamCell<A> = Rc<RefCell<MultiParam<A>>>;
+
+pub struct MultiParamHandle<A: ArbitraryParamsAcceptance> {
+    cell: MultiParamCell<A>,
+}
+
+pub type MultiParamAcceptsArbitraryHandle = MultiParamHandle<AcceptsArbitraryParams>;
+
+impl MultiParamAcceptsArbitraryHandle {
+    pub fn get_arbitrary(self) -> Option<HashMap<String, String>> {
+        let param_name = self.cell.borrow().prefix;
+        match Rc::try_unwrap(self.cell) {
+            Ok(cell) => cell.into_inner().get_arbitrary(),
+            Err(_) => panic!("Something holds the reference to `{param_name}` param cell. Make sure the parser is consumed with Parser::parse before calling this method."),
+        }
+    }
+}
+
+impl<A: ArbitraryParamsAcceptance> MultiParamHandle<A> {
+    pub fn new(cell: MultiParamCell<A>) -> Self {
+        Self { cell }
+    }
+}
+
+impl<A: ArbitraryParamsAcceptance + 'static> ParamHandle for MultiParamHandle<A> {
+    fn cell(&self) -> ParamCell {
+        Rc::clone(&self.cell) as ParamCell
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::settings::param::Param;
+
+    use super::MultiParam;
+
+    #[test]
+    fn multi_param_arbitrary_test() {
+        let mut multi_param = MultiParam::new("replication", Vec::new(), "description", false);
+
+        assert!(multi_param
+            .parse("replication(foo=bar,key=value,gear=five)")
+            .is_ok());
+        multi_param.set_satisfied();
+
+        let parsed = multi_param.get_arbitrary().unwrap();
+        assert_eq!(&String::from("bar"), parsed.get("foo").unwrap());
+        assert_eq!(&String::from("value"), parsed.get("key").unwrap());
+        assert_eq!(&String::from("five"), parsed.get("gear").unwrap());
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/settings/param/parser.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/parser.rs
@@ -109,9 +109,9 @@ impl ParamsParser {
     }
 
     /// Creates a new group of the parameters.
-    pub fn group(&mut self, params: Vec<&dyn ParamHandle>) {
+    pub fn group(&mut self, params: &[&dyn ParamHandle]) {
         self.groups.push(ParamsGroup::new(
-            params.into_iter().map(|handle| handle.cell()).collect(),
+            params.iter().map(|handle| handle.cell()).collect(),
         ))
     }
 
@@ -201,8 +201,8 @@ mod tests {
 
         // Group the parameters. Meaning that if a user defined,
         // for example `count=` and `duration=` at the same time, the parsing should fail.
-        parser.group(vec![&count, &foo]);
-        parser.group(vec![&duration]);
+        parser.group(&[&count, &foo]);
+        parser.group(&[&duration]);
 
         (
             parser,

--- a/src/bin/cql-stress-cassandra-stress/settings/param/parser.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/parser.rs
@@ -223,7 +223,7 @@ mod tests {
 
         // We can now retrieve the parsed values from the handles.
         assert_eq!(Some(100), handles.count.get());
-        assert!(handles.foo.supplied_by_user());
+        assert!(handles.foo.get().is_some());
 
         // Even though `duration` has some default value, it doesn't belong
         // to the same group as `count`. This is why we get `None`.

--- a/src/bin/cql-stress-cassandra-stress/settings/param/simple_param.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/simple_param.rs
@@ -134,10 +134,6 @@ impl<T: Parsable> SimpleParamHandle<T> {
             Err(_) => panic!("Something holds the reference to `{param_name}` param cell. Make sure the parser is consumed with Parser::parse before calling this method."),
         }
     }
-
-    pub fn supplied_by_user(&self) -> bool {
-        self.cell.borrow().supplied_by_user()
-    }
 }
 
 impl<T: Parsable + 'static> ParamHandle for SimpleParamHandle<T> {

--- a/src/bin/cql-stress-cassandra-stress/settings/param/types.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/types.rs
@@ -152,3 +152,14 @@ impl Parsable for Count {
         Ok(value * multiplier)
     }
 }
+
+pub struct CommaDelimitedList;
+
+impl Parsable for CommaDelimitedList {
+    type Parsed = Vec<String>;
+
+    fn parse(s: &str) -> Result<Self::Parsed> {
+        ensure_regex!(s, r"^[^=,]+(,[^=,]+)*$");
+        Ok(s.split(',').map(|e| e.to_owned()).collect())
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/settings/param/types.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/types.rs
@@ -163,3 +163,19 @@ impl Parsable for CommaDelimitedList {
         Ok(s.split(',').map(|e| e.to_owned()).collect())
     }
 }
+
+pub struct Rate;
+
+impl Parsable for Rate {
+    type Parsed = u64;
+
+    fn parse(s: &str) -> Result<Self::Parsed> {
+        ensure_regex!(s, r"^[0-9]+/s$");
+
+        let value_slice = &s[..s.len() - 2];
+        let value = value_slice
+            .parse::<u64>()
+            .with_context(|| format!("Invalid u64 value: {value_slice}"))?;
+        Ok(value)
+    }
+}


### PR DESCRIPTION
Introduced modules:
* settings::option - Parses options and its parameters

Supported options:
-node
-schema
-rate

These options should be enough for implementing the runtime.

Apart from that - extended parameters' parsing module by introducing `MultiParam`. A multiparameter is a complex parameter that contains subparameters. For example, given the output of `./cassandra-stress help -schema`:
```
Usage: -schema [replication(?)] [keyspace=?] [compaction(?)] [compression=?]

  replication([strategy=?][factor=?][<option 1..N>=?]): Define the replication strategy and any parameters
      strategy=? (default=org.apache.cassandra.locator.SimpleStrategy) The replication strategy to use
      factor=? (default=1)                     The number of replicas
  keyspace=? (default=keyspace1)           The keyspace name to use
  compaction([strategy=?][<option 1..N>=?]): Define the compaction strategy and any parameters
      strategy=?                               The compaction strategy to use
  compression=?                            Specify the compression to use for sstable, default:no compression

```

`-schema` option uses two multiparameters: `replication` and `compaction`. They both have some predefined subparameters. `replication` accepts two of them, which are: `strategy`, and `factor`. Apart from that, both `replication` and `strategy` accept some arbitrary parameters (denoted by `<option 1..N>=?`). The arbitrary parameters must match pattern `key=value` and in the case of `-schema` option, will be correspondingly appended when defining `replication` and `compaction`.

`MultiParam` is responsible for parsing such parameters.