### PR TITLE
c-s runtime: write and read scenarios

### DIFF
--- a/src/bin/cql-stress-cassandra-stress/java_generate/values/hex_blob.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/values/hex_blob.rs
@@ -1,3 +1,5 @@
+use scylla::frame::response::result::CqlValue;
+
 use super::ValueGenerator;
 use crate::java_generate::distribution::Distribution;
 
@@ -7,13 +9,11 @@ use crate::java_generate::distribution::Distribution;
 pub struct HexBlob;
 
 impl ValueGenerator for HexBlob {
-    type Value = Vec<u8>;
-
     fn generate(
         &mut self,
         identity_distribution: &mut dyn Distribution,
         size_distribution: &mut dyn Distribution,
-    ) -> Self::Value {
+    ) -> CqlValue {
         let seed = identity_distribution.next_i64();
         size_distribution.set_seed(seed);
         let size = size_distribution.next_i64() as usize;
@@ -38,7 +38,7 @@ impl ValueGenerator for HexBlob {
             i += 16;
         }
 
-        result
+        CqlValue::Blob(result)
     }
 }
 
@@ -48,11 +48,16 @@ mod tests {
         distribution::{fixed::FixedDistribution, sequence::SeqDistribution, Distribution},
         values::{Generator, GeneratorConfig},
     };
+    use scylla::frame::response::result::CqlValue;
 
     use super::HexBlob;
 
-    fn to_vec_i8(v: Vec<u8>) -> Vec<i8> {
-        v.into_iter().map(|x| x as i8).collect::<Vec<i8>>()
+    fn to_vec_i8(v: CqlValue) -> Vec<i8> {
+        v.as_blob()
+            .unwrap()
+            .iter()
+            .map(|x| *x as i8)
+            .collect::<Vec<i8>>()
     }
 
     #[test]

--- a/src/bin/cql-stress-cassandra-stress/java_generate/values/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/values/mod.rs
@@ -1,8 +1,14 @@
 use super::distribution::{uniform::UniformDistribution, Distribution};
-use scylla::transport::partitioner::{Murmur3Partitioner, Partitioner};
+use scylla::{
+    frame::response::result::CqlValue,
+    transport::partitioner::{Murmur3Partitioner, Partitioner},
+};
 
 pub mod blob;
 pub mod hex_blob;
+
+pub use blob::Blob;
+pub use hex_blob::HexBlob;
 
 /// Generic generator of random values.
 /// Holds the distributions that the seeds and sizes are sampled from.
@@ -38,7 +44,7 @@ impl<T: ValueGenerator> Generator<T> {
         self.identity_distribution.set_seed(seed ^ self.salt);
     }
 
-    pub fn generate(&mut self) -> T::Value {
+    pub fn generate(&mut self) -> CqlValue {
         self.gen.generate(
             self.identity_distribution.as_mut(),
             self.size_distribution.as_mut(),
@@ -83,13 +89,11 @@ impl GeneratorConfig {
 
 /// The actual value Generator trait.
 pub trait ValueGenerator {
-    type Value;
-
     fn generate(
         &mut self,
         identity_distribution: &mut dyn Distribution,
         size_distribution: &mut dyn Distribution,
-    ) -> Self::Value;
+    ) -> CqlValue;
 }
 
 #[cfg(test)]

--- a/src/bin/cql-stress-cassandra-stress/main.rs
+++ b/src/bin/cql-stress-cassandra-stress/main.rs
@@ -5,6 +5,9 @@ mod settings;
 #[macro_use]
 extern crate lazy_static;
 
+#[macro_use]
+extern crate async_trait;
+
 use crate::settings::parse_cassandra_stress_args;
 use anyhow::Result;
 use std::env;

--- a/src/bin/cql-stress-cassandra-stress/main.rs
+++ b/src/bin/cql-stress-cassandra-stress/main.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate async_trait;
+
 mod java_generate;
 mod operation;
 mod settings;
@@ -5,22 +8,30 @@ mod settings;
 #[macro_use]
 extern crate lazy_static;
 
-#[macro_use]
-extern crate async_trait;
+use crate::{
+    operation::{ReadOperationFactory, RowGeneratorFactory},
+    settings::{parse_cassandra_stress_args, Command, ThreadsInfo},
+};
+use anyhow::{Context, Result};
+use cql_stress::configuration::{Configuration, OperationFactory};
+use operation::WriteOperationFactory;
+use scylla::{Session, SessionBuilder};
+use std::{env, sync::Arc};
+use tracing_subscriber::EnvFilter;
 
-use crate::settings::parse_cassandra_stress_args;
-use anyhow::Result;
-use std::env;
-
-use settings::CassandraStressParsingResult;
+use settings::{CassandraStressParsingResult, CassandraStressSettings};
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or(EnvFilter::new("warn")))
+        .init();
+
     // Cassandra-stress CLI is case-insensitive.
-    let payload = match parse_cassandra_stress_args(env::args().map(|arg| arg.to_lowercase())) {
+    let settings = match parse_cassandra_stress_args(env::args().map(|arg| arg.to_lowercase())) {
         // Special commands: help, print, version
         Ok(CassandraStressParsingResult::SpecialCommand) => return Ok(()),
-        Ok(CassandraStressParsingResult::Workload(payload)) => payload,
+        Ok(CassandraStressParsingResult::Workload(payload)) => Arc::new(*payload),
         Err(e) => {
             // For some reason cassandra-stress writes all parsing-related
             // error messages to stdout. We will follow the same approach.
@@ -29,7 +40,79 @@ async fn main() -> Result<()> {
         }
     };
 
-    payload.print_settings();
+    settings.print_settings();
+    let run_config = prepare_run(Arc::clone(&settings))
+        .await
+        .context("Failed to prepare benchmark")?;
 
+    let (_ctrl, run_finished) = cql_stress::run::run(run_config);
+
+    run_finished.await
+}
+
+async fn prepare_run(settings: Arc<CassandraStressSettings>) -> Result<Configuration> {
+    let builder = SessionBuilder::new().known_nodes(&settings.node.nodes);
+
+    let session = builder.build().await?;
+    let session = Arc::new(session);
+
+    create_schema(&session, &settings).await?;
+
+    let duration = settings.command_params.basic_params.duration;
+
+    let (concurrency, throttle) = match settings.rate.threads_info {
+        ThreadsInfo::Fixed {
+            threads, throttle, ..
+        } => (threads, throttle.map(|th| th as f64)),
+        ThreadsInfo::Auto { .. } => {
+            anyhow::bail!("Runtime not implemented for auto-adjusting rate configuration");
+        }
+    };
+
+    let operation_factory = create_operation_factory(session, settings).await?;
+
+    Ok(Configuration {
+        max_duration: duration,
+        concurrency,
+        rate_limit_per_second: throttle,
+        operation_factory,
+        max_retries_per_op: 0,
+    })
+}
+
+async fn create_schema(session: &Session, settings: &CassandraStressSettings) -> Result<()> {
+    session
+        .query(settings.schema.construct_keyspace_creation_query(), ())
+        .await?;
+    session
+        .use_keyspace(&settings.schema.keyspace, true)
+        .await?;
+    session
+        .query(settings.schema.construct_table_creation_query(), ())
+        .await
+        .context("Failed to create standard table")?;
+    session
+        .query(settings.schema.construct_counter_table_creation_query(), ())
+        .await
+        .context("Failed to create counter table")?;
     Ok(())
+}
+
+async fn create_operation_factory(
+    session: Arc<Session>,
+    settings: Arc<CassandraStressSettings>,
+) -> Result<Arc<dyn OperationFactory>> {
+    let workload_factory = RowGeneratorFactory::new(Arc::clone(&settings));
+    match &settings.command {
+        Command::Write => Ok(Arc::new(
+            WriteOperationFactory::new(settings, session, workload_factory).await?,
+        )),
+        Command::Read => Ok(Arc::new(
+            ReadOperationFactory::new(settings, session, workload_factory).await?,
+        )),
+        cmd => Err(anyhow::anyhow!(
+            "Runtime for command '{}' not implemented yet.",
+            cmd.show()
+        )),
+    }
 }

--- a/src/bin/cql-stress-cassandra-stress/main.rs
+++ b/src/bin/cql-stress-cassandra-stress/main.rs
@@ -74,6 +74,11 @@ async fn prepare_run(settings: Arc<CassandraStressSettings>) -> Result<Configura
         .build();
     builder = builder.default_execution_profile_handle(default_exec_profile.into_handle());
 
+    // TODO: Adjust port when `-port` option is supported.
+    if let Some(host_filter) = settings.node.host_filter(9042) {
+        builder = builder.host_filter(host_filter?)
+    }
+
     let session = builder.build().await?;
     let session = Arc::new(session);
 

--- a/src/bin/cql-stress-cassandra-stress/main.rs
+++ b/src/bin/cql-stress-cassandra-stress/main.rs
@@ -1,4 +1,5 @@
 mod java_generate;
+mod operation;
 mod settings;
 
 #[macro_use]

--- a/src/bin/cql-stress-cassandra-stress/operation/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/mod.rs
@@ -1,0 +1,21 @@
+mod row_generator;
+
+use anyhow::Result;
+use std::num::Wrapping;
+
+pub use row_generator::RowGeneratorFactory;
+use scylla::{frame::response::result::CqlValue, QueryResult};
+
+/// See https://github.com/scylladb/scylla-tools-java/blob/master/tools/stress/src/org/apache/cassandra/stress/generate/PartitionIterator.java#L725.
+fn recompute_seed(seed: i64, partition_key: &CqlValue) -> i64 {
+    match partition_key {
+        CqlValue::Blob(key) => {
+            let mut wrapped = Wrapping(seed);
+            for byte in key {
+                wrapped = (wrapped * Wrapping(31)) + Wrapping(*byte as i64);
+            }
+            wrapped.0
+        }
+        _ => todo!("Implement recompute_seed for other CqlValues"),
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/operation/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/mod.rs
@@ -1,9 +1,11 @@
+mod read;
 mod row_generator;
 mod write;
 
 use anyhow::Result;
 use std::num::Wrapping;
 
+pub use read::ReadOperationFactory;
 pub use row_generator::RowGeneratorFactory;
 use scylla::{frame::response::result::CqlValue, QueryResult};
 pub use write::WriteOperationFactory;
@@ -20,4 +22,53 @@ fn recompute_seed(seed: i64, partition_key: &CqlValue) -> i64 {
         }
         _ => todo!("Implement recompute_seed for other CqlValues"),
     }
+}
+
+fn validate_row(generated_row: &[CqlValue], query_result: QueryResult) -> Result<()> {
+    let rows = match query_result.rows {
+        Some(rows) => rows,
+        None => anyhow::bail!("Query result doesn't contain any rows.",),
+    };
+
+    let first_row = match rows.split_first() {
+        Some((first_row, remaining_rows)) => {
+            // Note that row-generation logic behaves in a way that given partition_key,
+            // there is exactly one row with this partition_key.
+            anyhow::ensure!(
+                remaining_rows.is_empty(),
+                "Multiple rows matched the key. Rows: {:?}",
+                rows
+            );
+            first_row
+        }
+        None => anyhow::bail!("Query result doesn't contain any rows.",),
+    };
+
+    anyhow::ensure!(
+        first_row.columns.len() == generated_row.len(),
+        "Expected row's ({:?}) length: {}. Result row's ({:?}) length: {}",
+        generated_row,
+        generated_row.len(),
+        first_row.columns,
+        first_row.columns.len(),
+    );
+
+    let result =
+        first_row
+            .columns
+            .iter()
+            .zip(generated_row.iter())
+            .all(|(maybe_result, expected)| match maybe_result {
+                Some(result) => result == expected,
+                // TODO: For now, we don't permit NULLs.
+                None => false,
+            });
+
+    anyhow::ensure!(
+        result,
+        "The data doesn't match. Result: {:?}. Expected: {:?}.",
+        first_row.columns,
+        generated_row,
+    );
+    Ok(())
 }

--- a/src/bin/cql-stress-cassandra-stress/operation/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/mod.rs
@@ -1,10 +1,12 @@
 mod row_generator;
+mod write;
 
 use anyhow::Result;
 use std::num::Wrapping;
 
 pub use row_generator::RowGeneratorFactory;
 use scylla::{frame::response::result::CqlValue, QueryResult};
+pub use write::WriteOperationFactory;
 
 /// See https://github.com/scylladb/scylla-tools-java/blob/master/tools/stress/src/org/apache/cassandra/stress/generate/PartitionIterator.java#L725.
 fn recompute_seed(seed: i64, partition_key: &CqlValue) -> i64 {

--- a/src/bin/cql-stress-cassandra-stress/operation/read.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/read.rs
@@ -1,0 +1,108 @@
+use std::{ops::ControlFlow, sync::Arc};
+
+use cql_stress::{
+    configuration::{Operation, OperationContext, OperationFactory},
+    make_runnable,
+};
+
+use anyhow::{Context, Result};
+use scylla::{prepared_statement::PreparedStatement, Session};
+
+use crate::settings::CassandraStressSettings;
+
+use super::{
+    row_generator::{RowGenerator, RowGeneratorFactory},
+    validate_row,
+};
+
+pub struct ReadOperation {
+    session: Arc<Session>,
+    statement: PreparedStatement,
+    workload: RowGenerator,
+    max_operations: Option<u64>,
+}
+
+pub struct ReadOperationFactory {
+    session: Arc<Session>,
+    statement: PreparedStatement,
+    workload_factory: RowGeneratorFactory,
+    max_operations: Option<u64>,
+}
+
+impl OperationFactory for ReadOperationFactory {
+    fn create(&self) -> Box<dyn Operation> {
+        Box::new(ReadOperation {
+            session: Arc::clone(&self.session),
+            statement: self.statement.clone(),
+            workload: self.workload_factory.create(),
+            max_operations: self.max_operations,
+        })
+    }
+}
+
+impl ReadOperationFactory {
+    pub async fn new(
+        settings: Arc<CassandraStressSettings>,
+        session: Arc<Session>,
+        workload_factory: RowGeneratorFactory,
+    ) -> Result<Self> {
+        let statement_str = "SELECT * FROM standard1 WHERE KEY=?";
+        let mut statement = session
+            .prepare(statement_str)
+            .await
+            .context("Failed to prepare statement")?;
+
+        statement.set_is_idempotent(true);
+        statement.set_consistency(settings.command_params.basic_params.consistency_level);
+        statement.set_serial_consistency(Some(
+            settings
+                .command_params
+                .basic_params
+                .serial_consistency_level,
+        ));
+
+        Ok(Self {
+            session,
+            statement,
+            workload_factory,
+            max_operations: settings.command_params.basic_params.operation_count,
+        })
+    }
+}
+
+make_runnable!(ReadOperation);
+impl ReadOperation {
+    async fn execute(&mut self, ctx: &OperationContext) -> Result<ControlFlow<()>> {
+        if self
+            .max_operations
+            .is_some_and(|max_ops| ctx.operation_id >= max_ops)
+        {
+            return Ok(ControlFlow::Break(()));
+        }
+
+        let row = self.workload.generate_row();
+        let pk = &row[0];
+
+        let result = self.session.execute(&self.statement, (pk,)).await;
+        if let Err(err) = result.as_ref() {
+            tracing::error!(
+                error = %err,
+                partition_key = ?pk,
+                "read error",
+            );
+        }
+
+        let validation_result = validate_row(&row, result?);
+        if let Err(err) = validation_result.as_ref() {
+            tracing::error!(
+                error = %err,
+                partition_key = ?pk,
+                "read validation error",
+            );
+        }
+        validation_result
+            .with_context(|| format!("Row with partition_key: {:?} could not be validated.", pk))?;
+
+        Ok(ControlFlow::Continue(()))
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/operation/row_generator.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/row_generator.rs
@@ -1,0 +1,162 @@
+use scylla::_macro_internal::CqlValue;
+
+use crate::{
+    java_generate::{
+        distribution::{fixed::FixedDistribution, sequence::SeqDistribution, Distribution},
+        values::{Blob, Generator, GeneratorConfig, HexBlob},
+    },
+    settings::CassandraStressSettings,
+};
+use std::sync::Arc;
+
+use super::recompute_seed;
+
+/// A row generator structure.
+///
+/// Row-generation logic:
+/// - sample the `pk_seed` from `pk_seed_distribution`
+/// - seed the `pk_generator` with sampled `pk_seed`
+/// - generate the partition key with `pk_generator`
+/// - compute the seed for the `column_generators` based on generated pk
+/// - generate the rest of the row (seeding the `column_generators` with computed seed)
+///
+/// I think it's a great place to address how read and write workloads cooperate.
+/// For reference, see: https://github.com/scylladb/cql-stress/pull/43#discussion_r1304274035.
+///
+/// At first, we need to notice that as long as `pk_seed_distribution` is a DETERMINISTIC distribution,
+/// the row-generation logic is also deterministic.
+/// The `pk_seed_distribution` is the one provided via CLI with either `-pop seq` or `-pop dist` option.
+/// Notice that `-pop seq=1..5` is short for `-pop dist=SEQ(1..5)`.
+///
+/// Note: a deterministic distribution in this case, is a distribution which samples the exact same values
+/// in each execution.
+/// In c-s, there are only two deterministic distributions:
+/// - FIXED
+/// - SEQ
+/// We call a distribution non-deterministic if the values it samples in each run may differ. It's the case
+/// for all of the distributions that depend on some RNG (which is by default seeded with current time in millis)
+/// e.g. UniformDistribution, GaussianDistribution (not yet implemented).
+///
+/// For example, each time we execute the command:
+/// ```
+/// ./cassandra-stress write n=100 -pop dist=SEQ(1..100)
+/// ```
+/// it will result in generating the exact same set of 100 rows (no matter the order of sampling - this distribution is shared across multiple threads).
+///
+/// Now, one can validate the inserted data with a read routine.
+/// Each of these commands will be successful (meaning, the data will be successfully validated):
+/// ```
+/// ./cassandra-stress read n=100 -pop dist=SEQ(1..100)
+/// ./cassandra-stress read n=100 -pop dist=UNIFORM(1..100)
+/// ./cassandra-stress read n=100 -pop dist=GAUSSIAN(30..70)
+/// ```
+///
+/// To be more precise: any read workload that samples the partition_key seeds from the distribution
+/// sampling the values from the subset of range 1..100 (one used in the write routine) will successfully validate the data.
+///
+/// This also means, that if we used a NON-DETERMINISTIC distribution e.g. `UniformDistribution` (which is by default seeded with current time as millis)
+/// in the write workload, most of the times, the read workload will result in a validation error.
+/// For example:
+/// ```
+/// ./cassandra-stress write n=100 -pop dist=UNIFORM(1..100)
+/// ./cassandra-stress read n=100 -pop dist=UNIFORM(1..100)
+/// ```
+/// will fail with a high probability.
+///
+/// There was a proposal to seed non-deterministic distributions with operation_id.
+/// Consider introducing this improvement in the future. This would result in c-s frontend being fully deterministic,
+/// no matter the distribution we sample the pk seeds from. I think it's a great improvement - unfortunately,
+/// it's not how Java's c-s behaves.
+/// Ref: https://github.com/scylladb/cql-stress/pull/45#discussion_r1312627399.
+///
+/// This is why, the write workload is almost always executed with the deterministic distribution
+/// such as `SeqDistribution`. See usage examples in https://github.com/scylladb/scylla-cluster-tests.
+///
+/// Notice that, this also means we can insert the data using cql-stress' c-s frontend,
+/// and then validate it using Java's implementation of c-s (and vice-versa).
+pub struct RowGenerator {
+    pk_seed_distribution: Arc<dyn Distribution>,
+    pk_generator: Generator<HexBlob>,
+    column_generators: Vec<Generator<Blob>>,
+}
+
+pub struct RowGeneratorFactory {
+    pk_seed_distribution: Arc<dyn Distribution>,
+    // TODO: Use settings to define pk_generator and column_generators
+    // once -pop and -col options are supported.
+    _settings: Arc<CassandraStressSettings>,
+}
+
+impl RowGenerator {
+    pub fn generate_row(&mut self) -> Vec<CqlValue> {
+        // +1 for partition_key.
+        let row_length = self.column_generators.len() + 1;
+        let mut result = Vec::with_capacity(row_length);
+
+        // Sample the partition_key seed from the shared distribution.
+        let pk_seed = self.pk_seed_distribution.next_i64();
+        self.pk_generator.set_seed(pk_seed);
+        let key = self.pk_generator.generate();
+
+        // Compute the seed used for generating the rest of the row.
+        let columns_seed = recompute_seed(0, &key);
+        result.push(key);
+
+        for column_generator in self.column_generators.iter_mut() {
+            column_generator.set_seed(columns_seed);
+            result.push(column_generator.generate());
+        }
+
+        result
+    }
+}
+
+impl RowGeneratorFactory {
+    pub fn new(settings: Arc<CassandraStressSettings>) -> Self {
+        // TODO: adjust when `-pop` option is supported.
+        let default_seq_range_end = settings
+            .command_params
+            .basic_params
+            .operation_count
+            .unwrap_or(1000000);
+        let pk_seed_distribution =
+            Arc::new(SeqDistribution::new(1, default_seq_range_end as i64).unwrap());
+
+        Self {
+            pk_seed_distribution,
+            _settings: settings,
+        }
+    }
+
+    pub fn create(&self) -> RowGenerator {
+        // See https://github.com/scylladb/scylla-tools-java/blob/master/tools/stress/src/org/apache/cassandra/stress/settings/SettingsCommandPreDefined.java#L77.
+        let pk_generator = Generator::new(
+            HexBlob,
+            GeneratorConfig::new(
+                "randomstrkey",
+                None,
+                Some(Box::new(FixedDistribution::new(10))),
+            ),
+        );
+
+        // TODO: adjust when `-col` option is supported.
+        let column_generators = (0..5)
+            .map(|n| {
+                Generator::new(
+                    Blob::default(),
+                    GeneratorConfig::new(
+                        &format!("randomstrC{}", n),
+                        None,
+                        Some(Box::new(FixedDistribution::new(34))),
+                    ),
+                )
+            })
+            .collect();
+
+        RowGenerator {
+            pk_seed_distribution: Arc::clone(&self.pk_seed_distribution),
+            pk_generator,
+            column_generators,
+        }
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/operation/write.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/write.rs
@@ -1,0 +1,94 @@
+use std::{ops::ControlFlow, sync::Arc};
+
+use cql_stress::{
+    configuration::{Operation, OperationContext, OperationFactory},
+    make_runnable,
+};
+
+use anyhow::{Context, Result};
+use scylla::{prepared_statement::PreparedStatement, Session};
+
+use crate::settings::CassandraStressSettings;
+
+use super::row_generator::{RowGenerator, RowGeneratorFactory};
+
+pub struct WriteOperation {
+    session: Arc<Session>,
+    statement: PreparedStatement,
+    workload: RowGenerator,
+    max_operations: Option<u64>,
+}
+
+pub struct WriteOperationFactory {
+    session: Arc<Session>,
+    statement: PreparedStatement,
+    workload_factory: RowGeneratorFactory,
+    max_operations: Option<u64>,
+}
+
+impl OperationFactory for WriteOperationFactory {
+    fn create(&self) -> Box<dyn Operation> {
+        Box::new(WriteOperation {
+            session: Arc::clone(&self.session),
+            statement: self.statement.clone(),
+            workload: self.workload_factory.create(),
+            max_operations: self.max_operations,
+        })
+    }
+}
+
+impl WriteOperationFactory {
+    pub async fn new(
+        settings: Arc<CassandraStressSettings>,
+        session: Arc<Session>,
+        workload_factory: RowGeneratorFactory,
+    ) -> Result<Self> {
+        let statement_str =
+            "INSERT INTO standard1 (key, \"C0\", \"C1\", \"C2\", \"C3\", \"C4\") VALUES (?, ?, ?, ?, ?, ?)";
+        let mut statement = session
+            .prepare(statement_str)
+            .await
+            .context("Failed to prepare statement")?;
+
+        statement.set_is_idempotent(true);
+        statement.set_consistency(settings.command_params.basic_params.consistency_level);
+        statement.set_serial_consistency(Some(
+            settings
+                .command_params
+                .basic_params
+                .serial_consistency_level,
+        ));
+
+        Ok(Self {
+            session,
+            statement,
+            workload_factory,
+            max_operations: settings.command_params.basic_params.operation_count,
+        })
+    }
+}
+
+make_runnable!(WriteOperation);
+impl WriteOperation {
+    async fn execute(&mut self, ctx: &OperationContext) -> Result<ControlFlow<()>> {
+        if self
+            .max_operations
+            .is_some_and(|max_ops| ctx.operation_id >= max_ops)
+        {
+            return Ok(ControlFlow::Break(()));
+        }
+
+        let row = self.workload.generate_row();
+        let result = self.session.execute(&self.statement, &row).await;
+
+        if let Err(err) = result.as_ref() {
+            tracing::error!(
+                error = %err,
+                partition_key = ?row[0],
+                "write error",
+            );
+        }
+
+        Ok(ControlFlow::Continue(()))
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/settings/command/help.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/help.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 
 use crate::settings::{command::Command, option::Options};
 
-use super::{CommandParams, ParsePayload};
+use super::ParsePayload;
 
 pub fn print_help() {
     println!("Usage:      cassandra-stress <command> [options]");
@@ -13,11 +13,11 @@ pub fn print_help() {
     Options::print_generic_help();
 }
 
-fn print_command_help(command_str: &str) -> Result<CommandParams> {
+fn print_command_help(command_str: &str) -> Result<()> {
     match Command::parse(command_str) {
         Ok(cmd) => {
             cmd.print_help();
-            Ok(CommandParams::Special)
+            Ok(())
         }
         Err(_) => Err(anyhow::anyhow!(
             "Invalid command or option provided to command help"
@@ -25,12 +25,7 @@ fn print_command_help(command_str: &str) -> Result<CommandParams> {
     }
 }
 
-fn print_option_help(option_str: &str) -> Result<CommandParams> {
-    Options::print_help(option_str)?;
-    Ok(CommandParams::Special)
-}
-
-pub fn parse_help_command(payload: &mut ParsePayload) -> Result<CommandParams> {
+pub fn parse_help_command(payload: &mut ParsePayload) -> Result<()> {
     let params = payload.remove("help").unwrap_or_default();
 
     let (help_param, remaining_help_params) = params.split_first().unzip();
@@ -49,10 +44,10 @@ pub fn parse_help_command(payload: &mut ParsePayload) -> Result<CommandParams> {
     match (help_param, option_payload) {
         (Some(_), Some(_)) => anyhow::bail!("Invalid command/option provided to help"),
         (Some(command), None) => print_command_help(command),
-        (None, Some((option, _option_params))) => print_option_help(option),
+        (None, Some((option, _option_params))) => Options::print_help(option),
         (None, None) => {
             print_help();
-            Ok(CommandParams::Special)
+            Ok(())
         }
     }
 }

--- a/src/bin/cql-stress-cassandra-stress/settings/command/read_write.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/read_write.rs
@@ -331,7 +331,9 @@ pub fn parse_read_write_params(cmd: &Command, payload: &mut ParsePayload) -> Res
     let args = payload.remove(cmd.show()).unwrap();
     let (parser, handles) = prepare_parser(cmd.show());
     parser.parse(args)?;
-    Ok(CommandParams::BasicParams(parse_with_handles(handles)))
+    Ok(CommandParams {
+        basic_params: parse_with_handles(handles),
+    })
 }
 
 pub fn print_help_read_write(command_str: &str) {

--- a/src/bin/cql-stress-cassandra-stress/settings/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/mod.rs
@@ -22,7 +22,7 @@ use self::option::SchemaOption;
 
 pub struct CassandraStressSettings {
     pub command: Command,
-    pub params: CommandParams,
+    pub command_params: CommandParams,
     pub node: NodeOption,
     pub rate: RateOption,
     pub schema: SchemaOption,
@@ -31,7 +31,7 @@ pub struct CassandraStressSettings {
 impl CassandraStressSettings {
     pub fn print_settings(&self) {
         println!("******************** Stress Settings ********************");
-        self.params.print_settings(&self.command);
+        self.command_params.print_settings(&self.command);
         self.rate.print_settings();
         self.node.print_settings();
         self.schema.print_settings();
@@ -140,7 +140,7 @@ where
     let result = || {
         let (cmd, mut payload) = prepare_parse_payload(&args)?;
 
-        let (command, params) = match parse_command(cmd, &mut payload) {
+        let (command, command_params) = match parse_command(cmd, &mut payload) {
             Ok((_, None)) => return Ok(CassandraStressParsingResult::SpecialCommand),
             Ok((cmd, Some(params))) => (cmd, params),
             Err(e) => return Err(e),
@@ -173,7 +173,7 @@ where
         Ok(CassandraStressParsingResult::Workload(Box::new(
             CassandraStressSettings {
                 command,
-                params,
+                command_params,
                 node,
                 rate,
                 schema,

--- a/src/bin/cql-stress-cassandra-stress/settings/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/mod.rs
@@ -9,8 +9,8 @@ use anyhow::Result;
 #[cfg(test)]
 mod test;
 
-use command::Command;
-use command::CommandParams;
+pub use command::Command;
+pub use command::CommandParams;
 use regex::Regex;
 
 use crate::settings::command::print_help;
@@ -141,10 +141,8 @@ where
         let (cmd, mut payload) = prepare_parse_payload(&args)?;
 
         let (command, params) = match parse_command(cmd, &mut payload) {
-            Ok((_, CommandParams::Special)) => {
-                return Ok(CassandraStressParsingResult::SpecialCommand)
-            }
-            Ok((cmd, params)) => (cmd, params),
+            Ok((_, None)) => return Ok(CassandraStressParsingResult::SpecialCommand),
+            Ok((cmd, Some(params))) => (cmd, params),
             Err(e) => return Err(e),
         };
 

--- a/src/bin/cql-stress-cassandra-stress/settings/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/mod.rs
@@ -11,6 +11,7 @@ mod test;
 
 pub use command::Command;
 pub use command::CommandParams;
+pub use option::ThreadsInfo;
 use regex::Regex;
 
 use crate::settings::command::print_help;

--- a/src/bin/cql-stress-cassandra-stress/settings/option/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/option/mod.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 
 pub use node::NodeOption;
 pub use rate::RateOption;
+pub use rate::ThreadsInfo;
 pub use schema::SchemaOption;
 
 pub struct Options;

--- a/src/bin/cql-stress-cassandra-stress/settings/option/node.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/option/node.rs
@@ -1,9 +1,11 @@
 use std::{
     fs::File,
     io::{self, BufRead},
+    sync::Arc,
 };
 
 use anyhow::{Context, Result};
+use scylla::load_balancing::{DefaultPolicy, LoadBalancingPolicy};
 
 use crate::settings::{
     param::{types::CommaDelimitedList, ParamsParser, SimpleParamHandle},
@@ -60,6 +62,15 @@ impl NodeOption {
             whitelist,
             datacenter,
         })
+    }
+
+    /// Define a token-aware load balancing policy with a preferred datacenter (if specified).
+    pub fn load_balancing_policy(&self) -> Arc<dyn LoadBalancingPolicy> {
+        let mut builder = DefaultPolicy::builder().token_aware(true);
+        if let Some(datacenter) = &self.datacenter {
+            builder = builder.prefer_datacenter(datacenter.to_owned());
+        };
+        builder.build()
     }
 }
 

--- a/src/bin/cql-stress-cassandra-stress/settings/option/rate.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/option/rate.rs
@@ -5,7 +5,7 @@ use crate::settings::{
 use anyhow::Result;
 
 pub struct RateOption {
-    threads_info: ThreadsInfo,
+    pub threads_info: ThreadsInfo,
 }
 
 #[derive(PartialEq, Debug)]


### PR DESCRIPTION
# Changes
- Cosmetic changes in the settings module that simplify the access to the parameters (from the main).
- Introduced `operation` module.
- Implemented row-generation logic, based on c-s logic.
- Implemented write and read operations.
- Implemented main logic responsible for running the actual runtime scenario.