### PR TITLE
cql-stress tracing: replace `env_logger` with `tracing-subscriber`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,17 +50,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,7 +155,6 @@ dependencies = [
  "async-trait",
  "base64",
  "chrono",
- "env_logger",
  "futures",
  "hdrhistogram",
  "lazy_static",
@@ -253,19 +241,6 @@ name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
-
-[[package]]
-name = "env_logger"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
 
 [[package]]
 name = "flate2"
@@ -451,12 +426,6 @@ name = "histogram"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12cb882ccb290b8646e554b157ab0b71e64e8d5bef775cd66b6531e52d302669"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
@@ -1141,15 +1110,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,7 +1208,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
 dependencies = [
  "cfg-if",
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1440,15 +1399,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,7 @@ dependencies = [
  "thread_local",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -535,6 +536,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,6 +626,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.101",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -724,6 +744,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -867,8 +893,17 @@ checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.3.2",
+ "regex-syntax 0.7.4",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -879,8 +914,14 @@ checksum = "83d3daa6976cffb758ec878f108ba0e062a45b2d6ca3a2cca965338855476caf"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.4",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -982,6 +1023,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1217,11 +1267,41 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.29"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1260,6 +1340,12 @@ checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ anyhow = "1.0.52"
 async-trait = "0.1.52"
 base64 = "0.13.0"
 chrono = "0.4.9"
-env_logger = "0.9.0"
 futures = "0.3.19"
 hdrhistogram = "7.5.0"
 lazy_static = "1.4.0"
@@ -20,13 +19,15 @@ rand = "0.8"
 rand_distr = "0.4"
 rand_pcg = "0.3"
 regex = "1.9.1"
-scylla = {version = "0.8.1", features = ["ssl"]}
+scylla = { version = "0.8.1", features = ["ssl"] }
 sha2 = "0.10"
 strum = "0.25.0"
 strum_macros = "0.25.1"
 thread_local = "1.1.4"
-tokio = {version = "1.15.0", features = ["full"]}# TODO: Include only necessary features
-tracing = {version = "0.1.35", features = ["log"]}
+tokio = { version = "1.15.0", features = [
+    "full",
+] } # TODO: Include only necessary features
+tracing = "0.1.35"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ strum_macros = "0.25.1"
 thread_local = "1.1.4"
 tokio = {version = "1.15.0", features = ["full"]}# TODO: Include only necessary features
 tracing = {version = "0.1.35", features = ["log"]}
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 
 [dev-dependencies]
 ntest = "0.8"

--- a/src/bin/cql-stress-scylla-bench/main.rs
+++ b/src/bin/cql-stress-scylla-bench/main.rs
@@ -16,11 +16,11 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use env_logger::Env;
 use futures::future;
 use openssl::ssl::{SslContext, SslContextBuilder, SslFiletype, SslMethod, SslVerifyMode};
 use scylla::ExecutionProfile;
 use scylla::{transport::Compression, Session, SessionBuilder};
+use tracing_subscriber::EnvFilter;
 
 use cql_stress::configuration::{Configuration, OperationFactory};
 use cql_stress::run::RunController;
@@ -40,7 +40,9 @@ use crate::workload::{
 // TODO: Return exit code
 #[tokio::main]
 async fn main() -> Result<()> {
-    env_logger::Builder::from_env(Env::default().default_filter_or("warn")).init();
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or(EnvFilter::new("warn")))
+        .init();
 
     #[cfg(debug_assertions)]
     {


### PR DESCRIPTION
# Motivation
As stated in the first commit message, some [tracing](https://docs.rs/tracing/latest/tracing/) logs were not consumed (not displayed).

To be more precise: all logs emitted after the first `await` were simply ignored.

A simple example (before the changes). Adding two simple logs in
`src/bin/cql-stress-scylla-bench/main.rs::prepare`:
```rust
    tracing::info!("Before build");
    let session = builder.build().await?;
    tracing::info!("After build");
```

Now, looking at the output of some simple command:
```
$ RUST_LOG=info cargo run --release --bin cql-stress-scylla-bench -- -mode write -workload sequential -nodes "172.17.0.2:9042" --partition-count 100000
    Finished release [optimized] target(s) in 0.03s
     Running `target/release/cql-stress-scylla-bench -mode write -workload sequential -nodes '172.17.0.2:9042' --partition-count 100000`
Configuration
Mode:			 write
Workload:		 sequential
Timeout:		 5.0s
Consistency level:	 quorum
Partition count:	 100000
Clustering rows:	 100
Clustering row size:	 Fixed(4)
Rows per request:	 1
Page size:		 1000
Concurrency:		 16
Maximum rate:		 unlimited
Client compression:	 true
[2023-08-21T11:20:52Z INFO  cql_stress_scylla_bench] Before build
time        ops/s  rows/s errors    max 99.9th   99th   95th   90th median   mean
1.0s       167749  167749      0  547μs  291μs  238μs  180μs  129μs 84.6μs 95.1μs
2.0s       170120  170120      0  446μs  289μs  225μs  170μs  119μs 85.1μs 93.7μs
3.0s       161820  161820      0  476μs  303μs  252μs  190μs  160μs 85.3μs 98.6μs
4.0s       167056  167056      0  834μs  290μs  238μs  182μs  129μs 84.7μs 95.5μs
^C
Results:
Time (avg):	4.7s
Total ops:	790562
Total rows:	790562
Operations/s:	166757.87174464736
Rows/s:		166757.87174464736
raw latency:
  max:		834μs
  99.9th:	834μs
  99h:		241μs
  95h:		182μs
  90h:		129μs
  median:	84.9μs
  mean:		95.6μs
c-o fixed latency:
  max:		834μs
  99.9th:	834μs
  99h:		241μs
  95h:		182μs
  90h:		129μs
  median:	84.9μs
  mean:		95.6μs
```

We see that `After build` log didn't show up. It's emitted right after the first
`await` in the code (but not consumed by `env_logger` for some reason).

# Changes
- imported `tracing-subscriber` crate
-  replaced `env_logger` with `tracing_subscriber` in s-b main
- removed `env_logger` crate
- removed `tracing`'s  crate `log` feature