### PR TITLE
c-s: parser refactor

### DIFF
--- a/src/bin/cql-stress-cassandra-stress/main.rs
+++ b/src/bin/cql-stress-cassandra-stress/main.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<()> {
         Err(e) => {
             // For some reason cassandra-stress writes all parsing-related
             // error messages to stdout. We will follow the same approach.
-            println!("\n{e}");
+            println!("\n{:?}", e);
             return Err(anyhow::anyhow!("Failed to parse CLI arguments."));
         }
     };

--- a/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
@@ -2,6 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 
 mod parser;
 mod simple_param;
+pub mod types;
 use regex::Regex;
 
 pub use parser::ParamsParser;

--- a/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
@@ -3,14 +3,11 @@ use std::{cell::RefCell, rc::Rc};
 mod parser;
 mod simple_param;
 pub mod types;
-use regex::Regex;
+
+use anyhow::Result;
 
 pub use parser::ParamsParser;
 pub use simple_param::SimpleParamHandle;
-
-fn regex_is_empty(regex: &Regex) -> bool {
-    regex.as_str() == "^$"
-}
 
 /// An 'interface' of parameter.
 ///
@@ -25,8 +22,8 @@ pub trait Param {
     /// - ParamMatchResult::Error if argument matches the prefix, but doesn't satisfy the value pattern
     /// - ParamMatchResult::Match if argument matches both prefix and value pattern.
     fn try_match(&self, arg: &str) -> ParamMatchResult;
-    /// Sets the parameter's value to `arg`. Will panic if `try_match` doesn't return ParamMatchResult::Match.
-    fn parse(&mut self, arg: &str);
+    /// Parses the `arg` value.
+    fn parse(&mut self, arg: &str) -> Result<()>;
     /// Tells whether the parameter was parsed with the user-provided argument.
     fn supplied_by_user(&self) -> bool;
     fn required(&self) -> bool;

--- a/src/bin/cql-stress-cassandra-stress/settings/param/parser.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/parser.rs
@@ -3,6 +3,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use super::{
     simple_param::{SimpleParam, SimpleParamHandle},
+    types::Parsable,
     ParamCell, ParamHandle, ParamMatchResult,
 };
 
@@ -92,20 +93,15 @@ impl ParamsParser {
 
     /// Registers the simple parameter provided by the user and returns the handle.
     /// `value_pattern` has to be a regular expression, otherwise we panic.
-    pub fn simple_param(
+    pub fn simple_param<T: Parsable + 'static>(
         &mut self,
         prefix: &'static str,
-        value_pattern: &'static str,
         default: Option<&'static str>,
         desc: &'static str,
         required: bool,
-    ) -> SimpleParamHandle {
+    ) -> SimpleParamHandle<T> {
         let param = Rc::new(RefCell::new(SimpleParam::new(
-            prefix,
-            value_pattern,
-            default,
-            desc,
-            required,
+            prefix, default, desc, required,
         )));
 
         self.params.push(Rc::clone(&param) as ParamCell);
@@ -135,7 +131,7 @@ impl ParamsParser {
                     ParamMatchResult::Error(e) => return Err(e),
                     ParamMatchResult::NoMatch => (),
                     ParamMatchResult::Match => {
-                        borrowed.parse(arg);
+                        borrowed.parse(arg)?;
                         consumed = true;
                         break;
                     }
@@ -180,52 +176,58 @@ impl ParamsParser {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use crate::settings::param::SimpleParamHandle;
 
     use super::ParamsParser;
 
-    fn prepare_parser() -> (
-        ParamsParser,
-        (SimpleParamHandle, SimpleParamHandle, SimpleParamHandle),
-    ) {
+    struct TestHandles {
+        count: SimpleParamHandle<u64>,
+        foo: SimpleParamHandle<bool>,
+        duration: SimpleParamHandle<Duration>,
+    }
+
+    fn prepare_parser() -> (ParamsParser, TestHandles) {
         // Create a parser.
         let mut parser = ParamsParser::new("some_parser");
 
         // Define 3 parameters and get their corresponding handles.
-        let count = parser.simple_param("count=", r"^[0-9]+$", None, "this is count", true);
+        let count = parser.simple_param("count=", None, "this is count", true);
 
         // Parameters with empty value_pattern (regex) are boolean flags.
-        let foo = parser.simple_param("foo", r"^$", None, "this is foo", false);
-        let duration = parser.simple_param(
-            "duration=",
-            r"^[0-9]+[smh]$",
-            Some("10s"),
-            "this is duration",
-            false,
-        );
+        let foo = parser.simple_param("foo", None, "this is foo", false);
+        let duration = parser.simple_param("duration=", Some("10s"), "this is duration", false);
 
         // Group the parameters. Meaning that if a user defined,
         // for example `count=` and `duration=` at the same time, the parsing should fail.
         parser.group(vec![&count, &foo]);
         parser.group(vec![&duration]);
 
-        (parser, (count, foo, duration))
+        (
+            parser,
+            TestHandles {
+                count,
+                foo,
+                duration,
+            },
+        )
     }
 
     #[test]
     fn parser_success_test() {
         let args = vec!["count=100", "foo"];
-        let (parser, (count, foo, duration)) = prepare_parser();
+        let (parser, handles) = prepare_parser();
 
         assert!(parser.parse(args).is_ok());
 
         // We can now retrieve the parsed values from the handles.
-        assert_eq!(Some(100), count.get_type::<u64>());
-        assert!(foo.supplied_by_user());
+        assert_eq!(Some(100), handles.count.get());
+        assert!(handles.foo.supplied_by_user());
 
         // Even though `duration` has some default value, it doesn't belong
         // to the same group as `count`. This is why we get `None`.
-        assert_eq!(None, duration.get());
+        assert_eq!(None, handles.duration.get());
     }
 
     #[test]

--- a/src/bin/cql-stress-cassandra-stress/settings/param/types.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/types.rs
@@ -1,0 +1,154 @@
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+
+pub trait Parsable: Sized {
+    type Parsed;
+
+    fn parse(s: &str) -> Result<Self::Parsed>;
+
+    // Used only to print the same help message as cassandra-stress does for boolean flags.
+    fn is_bool() -> bool {
+        false
+    }
+}
+
+/// Simple macro for checking if value `s` matches the regex `regex_str`.
+/// Returns error if the value didn't match.
+macro_rules! ensure_regex {
+    ($s:ident, $regex_str:expr) => {
+        lazy_static! {
+            static ref RGX: regex::Regex = regex::Regex::new($regex_str).unwrap();
+        }
+        anyhow::ensure!(
+            RGX.is_match($s),
+            "Invalid value {}; must match pattern {}",
+            $s,
+            $regex_str
+        )
+    };
+}
+
+// Implementation of Parsable for common types.
+
+impl Parsable for u64 {
+    type Parsed = u64;
+
+    fn parse(s: &str) -> Result<Self::Parsed> {
+        ensure_regex!(s, r"^[0-9]+$");
+        s.parse::<u64>()
+            .with_context(|| format!("Invalid u64 value: {s}"))
+    }
+}
+
+impl Parsable for f64 {
+    type Parsed = f64;
+
+    fn parse(s: &str) -> Result<Self::Parsed> {
+        ensure_regex!(s, r"[0-9]+(\.[0-9]+)?");
+        s.parse::<f64>()
+            .with_context(|| format!("Invalid f64 argument: {s}"))
+    }
+}
+
+pub struct UnitInterval;
+impl Parsable for UnitInterval {
+    type Parsed = f64;
+
+    fn parse(s: &str) -> Result<Self::Parsed> {
+        ensure_regex!(s, r"^0\.[0-9]+$");
+        s.parse::<f64>()
+            .with_context(|| format!("Invalid f64 argument: {s}"))
+    }
+}
+
+impl Parsable for bool {
+    type Parsed = bool;
+
+    fn parse(s: &str) -> Result<Self::Parsed> {
+        anyhow::ensure!(
+            s.is_empty(),
+            "Invalid value {}. Boolean flag cannot have any value.",
+            s
+        );
+
+        Ok(true)
+    }
+
+    fn is_bool() -> bool {
+        true
+    }
+}
+
+impl Parsable for String {
+    type Parsed = String;
+
+    fn parse(s: &str) -> Result<Self::Parsed> {
+        Ok(s.to_owned())
+    }
+}
+
+impl Parsable for Duration {
+    type Parsed = Duration;
+
+    fn parse(s: &str) -> Result<Self::Parsed> {
+        ensure_regex!(s, r"^[0-9]+[smh]$");
+
+        let parse_duration_unit = |unit: char| -> Result<u64> {
+            match unit {
+                's' => Ok(1),
+                'm' => Ok(60),
+                'h' => Ok(60 * 60),
+                _ => anyhow::bail!("Invalid duration unit: {unit}"),
+            }
+        };
+
+        let multiplier = parse_duration_unit(
+            s.chars()
+                .last()
+                .ok_or_else(|| anyhow::anyhow!("Invalid argument: {}", s))?,
+        )?;
+        let value_str = &s[0..s.len() - 1];
+        let value = value_str
+            .parse::<u64>()
+            .with_context(|| format!("Invalid u64 value: {}", value_str))?;
+        Ok(Duration::from_secs(value * multiplier))
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+/// Wrapper over the parameter's value matching pattern "[0-9]+[bmk]?".
+/// [bmk] suffix denotes the multiplier. One of billion, million or thousand.
+pub struct Count;
+
+impl Parsable for Count {
+    type Parsed = u64;
+
+    fn parse(s: &str) -> Result<Self::Parsed> {
+        ensure_regex!(s, r"^[0-9]+[bmk]?$");
+
+        let parse_operation_count_unit = |unit: char| -> Result<u64> {
+            match unit {
+                'k' => Ok(1_000),
+                'm' => Ok(1_000_000),
+                'b' => Ok(1_000_000_000),
+                _ => anyhow::bail!("Invalid operation count unit: {unit}"),
+            }
+        };
+
+        let last = s
+            .chars()
+            .last()
+            .ok_or_else(|| anyhow::anyhow!("Invalid argument: {}", s))?;
+        let mut multiplier = 1;
+        let mut number_slice = s;
+        if last.is_alphabetic() {
+            multiplier = parse_operation_count_unit(last)?;
+            number_slice = &s[0..s.len() - 1];
+        }
+        let value = number_slice
+            .parse::<u64>()
+            .with_context(|| format!("Invalid u64 value: {}", number_slice))?;
+        Ok(value * multiplier)
+    }
+}


### PR DESCRIPTION
# Motivation
Before the changes, the parser would only validate the input, returning the validated string to the user (which still needs to be parsed to the according type).

# Changes
This PR introduces the changes that address this issue. The major change is the introduction of `Parsable` trait described in the code. The `SimpleParam` is now generic over `Parsable` trait.

Most of the changes include adjusting the rest of the code to `Parsable` trait + some fixups.

- Introduced `Parsable` trait
- Made `SimpleParam` be generic over `Parsable`
- Adjusted the rest of the code to usage of generic `SimpleParam`
- some fixups, such as changing the types of `duration`, or `consistency_level` parameters