### PR TITLE
c-s CLI: columns and population options

### DIFF
--- a/src/bin/cql-stress-cassandra-stress/java_generate/distribution/fixed.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/distribution/fixed.rs
@@ -60,3 +60,9 @@ impl FixedDistributionFactory {
         )
     }
 }
+
+impl std::fmt::Display for FixedDistributionFactory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "FIXED({})", self.0)
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/java_generate/distribution/fixed.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/distribution/fixed.rs
@@ -1,4 +1,8 @@
-use super::Distribution;
+use anyhow::{Context, Result};
+
+use cql_stress::distribution::Description;
+
+use super::{Distribution, DistributionFactory};
 
 /// Distribution that always returns fixed value.
 /// See: https://github.com/scylladb/scylla-tools-java/blob/master/tools/stress/src/org/apache/cassandra/stress/generate/DistributionFixed.java.
@@ -22,4 +26,37 @@ impl Distribution for FixedDistribution {
     }
 
     fn set_seed(&self, _seed: i64) {}
+}
+
+pub struct FixedDistributionFactory(pub i64);
+
+impl DistributionFactory for FixedDistributionFactory {
+    fn create(&self) -> Box<dyn Distribution> {
+        Box::new(FixedDistribution::new(self.0))
+    }
+}
+
+impl FixedDistributionFactory {
+    pub fn parse_from_description(desc: Description<'_>) -> Result<Box<dyn DistributionFactory>> {
+        let result = || -> Result<Box<dyn DistributionFactory>> {
+            desc.check_argument_count(1)?;
+            let value = desc.args[0].parse::<i64>()?;
+
+            Ok(Box::new(FixedDistributionFactory(value)))
+        }();
+
+        result.with_context(|| {
+            format!(
+                "Invalid parameter list for fixed distribution: {:?}",
+                desc.args
+            )
+        })
+    }
+
+    pub fn help_description() -> String {
+        format!(
+            "      {:<36} A fixed distribution, always returning the same value",
+            "FIXED(val)"
+        )
+    }
 }

--- a/src/bin/cql-stress-cassandra-stress/java_generate/distribution/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/distribution/mod.rs
@@ -45,8 +45,6 @@ impl ThreadLocalRandom {
     }
 }
 
-pub trait DistributionFactory {
-    type Distribution;
-
-    fn get(&self) -> Self::Distribution;
+pub trait DistributionFactory: Send + Sync {
+    fn create(&self) -> Box<dyn Distribution>;
 }

--- a/src/bin/cql-stress-cassandra-stress/java_generate/distribution/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/distribution/mod.rs
@@ -45,6 +45,6 @@ impl ThreadLocalRandom {
     }
 }
 
-pub trait DistributionFactory: Send + Sync {
+pub trait DistributionFactory: Send + Sync + std::fmt::Display {
     fn create(&self) -> Box<dyn Distribution>;
 }

--- a/src/bin/cql-stress-cassandra-stress/java_generate/distribution/sequence.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/distribution/sequence.rs
@@ -1,7 +1,8 @@
 use std::sync::atomic::{AtomicI64, Ordering};
 
-use super::Distribution;
-use anyhow::Result;
+use super::{Distribution, DistributionFactory};
+use anyhow::{Context, Result};
+use cql_stress::distribution::Description;
 
 /// Sequence distribution. Samples values from `start` to `end` in a sequence manner.
 /// Once the `end` is sampled, the cycle starts over again. It means that the sequence of the sampled values will look like:
@@ -20,8 +21,8 @@ pub struct SeqDistribution {
 impl SeqDistribution {
     pub fn new(start: i64, end: i64) -> Result<Self> {
         anyhow::ensure!(
-            start <= end,
-            "Upper bound ({}) for sequence distribution is smaller than the lower bound ({}).",
+            start < end,
+            "Upper bound ({}) for sequence distribution is smaller or equal than the lower bound ({}).",
             end,
             start
         );
@@ -52,6 +53,55 @@ impl Distribution for SeqDistribution {
 
     fn set_seed(&self, seed: i64) {
         self.seed.store(seed, Ordering::Relaxed);
+    }
+}
+
+pub struct SeqDistributionFactory {
+    min: i64,
+    max: i64,
+}
+
+impl SeqDistributionFactory {
+    pub fn new(min: i64, max: i64) -> Result<Self> {
+        anyhow::ensure!(
+            min < max,
+            "Upper bound ({}) for sequence distribution is smaller or equal than the lower bound ({}).",
+            max,
+            min
+        );
+
+        Ok(Self { min, max })
+    }
+}
+
+impl DistributionFactory for SeqDistributionFactory {
+    fn create(&self) -> Box<dyn Distribution> {
+        Box::new(SeqDistribution::new(self.min, self.max).unwrap())
+    }
+}
+
+impl SeqDistributionFactory {
+    pub fn parse_from_description(desc: Description<'_>) -> Result<Box<dyn DistributionFactory>> {
+        let result = || -> Result<Box<dyn DistributionFactory>> {
+            desc.check_argument_count(2)?;
+            let (min, max) = (desc.args[0].parse::<i64>()?, desc.args[1].parse::<i64>()?);
+
+            Ok(Box::new(SeqDistributionFactory::new(min, max)?))
+        }();
+
+        result.with_context(|| {
+            format!(
+                "Invalid parameter list for sequence distribution: {:?}",
+                desc.args
+            )
+        })
+    }
+
+    pub fn help_description() -> String {
+        format!(
+            "      {:<36} A fixed sequence, returning values in the range min to max sequentially (starting based on seed), wrapping if necessary.",
+            "SEQ(min..max)"
+        )
     }
 }
 

--- a/src/bin/cql-stress-cassandra-stress/java_generate/distribution/sequence.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/distribution/sequence.rs
@@ -105,6 +105,12 @@ impl SeqDistributionFactory {
     }
 }
 
+impl std::fmt::Display for SeqDistributionFactory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SEQ({}..{})", self.min, self.max)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::SeqDistribution;

--- a/src/bin/cql-stress-cassandra-stress/java_generate/distribution/uniform.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/distribution/uniform.rs
@@ -1,6 +1,9 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
+use cql_stress::distribution::Description;
 
-use super::{Distribution, ThreadLocalRandom};
+use super::{
+    fixed::FixedDistributionFactory, Distribution, DistributionFactory, ThreadLocalRandom,
+};
 
 /// Uniform real distribution that uses java.util.Random generator.
 /// The distribution samples real numbers from [lower, upper + 1)
@@ -45,6 +48,61 @@ impl Distribution for UniformDistribution {
 
     fn set_seed(&self, seed: i64) {
         self.rng.get().set_seed(seed as u64)
+    }
+}
+
+pub struct UniformDistributionFactory {
+    min: f64,
+    max: f64,
+}
+
+impl UniformDistributionFactory {
+    pub fn new(min: f64, max: f64) -> Result<Self> {
+        anyhow::ensure!(
+            min < max,
+            "Upper bound ({}) for real uniform distribution is not higher than the lower bound ({}).",
+            max,
+            min
+        );
+
+        Ok(Self { min, max })
+    }
+}
+
+impl DistributionFactory for UniformDistributionFactory {
+    fn create(&self) -> Box<dyn Distribution> {
+        Box::new(UniformDistribution::new(self.min, self.max).unwrap())
+    }
+}
+
+impl UniformDistributionFactory {
+    pub fn parse_from_description(desc: Description<'_>) -> Result<Box<dyn DistributionFactory>> {
+        let result = || -> Result<Box<dyn DistributionFactory>> {
+            desc.check_argument_count(2)?;
+            let (min, max) = (desc.args[0].parse::<i64>()?, desc.args[1].parse::<i64>()?);
+
+            if min == max {
+                Ok(Box::new(FixedDistributionFactory(min)))
+            } else {
+                Ok(Box::new(UniformDistributionFactory::new(
+                    min as f64, max as f64,
+                )?))
+            }
+        }();
+
+        result.with_context(|| {
+            format!(
+                "Invalid parameter list for uniform distribution: {:?}",
+                desc.args
+            )
+        })
+    }
+
+    pub fn help_description() -> String {
+        format!(
+            "      {:<36} A uniform distribution over the range [min, max]",
+            "UNIFORM(min..max)"
+        )
     }
 }
 

--- a/src/bin/cql-stress-cassandra-stress/java_generate/distribution/uniform.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/distribution/uniform.rs
@@ -106,6 +106,12 @@ impl UniformDistributionFactory {
     }
 }
 
+impl std::fmt::Display for UniformDistributionFactory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "UNIFORM({}..{})", self.min as i64, self.max as i64)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::UniformDistribution;

--- a/src/bin/cql-stress-cassandra-stress/main.rs
+++ b/src/bin/cql-stress-cassandra-stress/main.rs
@@ -159,11 +159,21 @@ async fn create_schema(session: &Session, settings: &CassandraStressSettings) ->
         .use_keyspace(&settings.schema.keyspace, true)
         .await?;
     session
-        .query(settings.schema.construct_table_creation_query(), ())
+        .query(
+            settings
+                .schema
+                .construct_table_creation_query(&settings.column.columns),
+            (),
+        )
         .await
         .context("Failed to create standard table")?;
     session
-        .query(settings.schema.construct_counter_table_creation_query(), ())
+        .query(
+            settings
+                .schema
+                .construct_counter_table_creation_query(&settings.column.columns),
+            (),
+        )
         .await
         .context("Failed to create counter table")?;
     Ok(())

--- a/src/bin/cql-stress-cassandra-stress/operation/row_generator.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/row_generator.rs
@@ -82,9 +82,7 @@ pub struct RowGenerator {
 
 pub struct RowGeneratorFactory {
     pk_seed_distribution: Arc<dyn Distribution>,
-    // TODO: Use settings to define pk_generator and column_generators
-    // once -pop and -col options are supported.
-    _settings: Arc<CassandraStressSettings>,
+    settings: Arc<CassandraStressSettings>,
 }
 
 impl RowGenerator {
@@ -117,7 +115,7 @@ impl RowGeneratorFactory {
 
         Self {
             pk_seed_distribution,
-            _settings: settings,
+            settings,
         }
     }
 
@@ -132,15 +130,18 @@ impl RowGeneratorFactory {
             ),
         );
 
-        // TODO: adjust when `-col` option is supported.
-        let column_generators = (0..5)
-            .map(|n| {
+        let column_generators = self
+            .settings
+            .column
+            .columns
+            .iter()
+            .map(|column| {
                 Generator::new(
                     Blob::default(),
                     GeneratorConfig::new(
-                        &format!("randomstrC{}", n),
+                        &format!("randomstr{}", column),
                         None,
-                        Some(Box::new(FixedDistribution::new(34))),
+                        Some(self.settings.column.size_distribution.create()),
                     ),
                 )
             })

--- a/src/bin/cql-stress-cassandra-stress/operation/row_generator.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/row_generator.rs
@@ -2,7 +2,7 @@ use scylla::_macro_internal::CqlValue;
 
 use crate::{
     java_generate::{
-        distribution::{fixed::FixedDistribution, sequence::SeqDistribution, Distribution},
+        distribution::{fixed::FixedDistribution, Distribution},
         values::{Blob, Generator, GeneratorConfig, HexBlob},
     },
     settings::CassandraStressSettings,
@@ -113,14 +113,7 @@ impl RowGenerator {
 
 impl RowGeneratorFactory {
     pub fn new(settings: Arc<CassandraStressSettings>) -> Self {
-        // TODO: adjust when `-pop` option is supported.
-        let default_seq_range_end = settings
-            .command_params
-            .basic_params
-            .operation_count
-            .unwrap_or(1000000);
-        let pk_seed_distribution =
-            Arc::new(SeqDistribution::new(1, default_seq_range_end as i64).unwrap());
+        let pk_seed_distribution = settings.population.pk_seed_distribution.create().into();
 
         Self {
             pk_seed_distribution,

--- a/src/bin/cql-stress-cassandra-stress/operation/write.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/write.rs
@@ -47,8 +47,16 @@ impl WriteOperationFactory {
         workload_factory: RowGeneratorFactory,
         stats: Arc<ShardedStats>,
     ) -> Result<Self> {
-        let statement_str =
-            "INSERT INTO standard1 (key, \"C0\", \"C1\", \"C2\", \"C3\", \"C4\") VALUES (?, ?, ?, ?, ?, ?)";
+        let mut statement_str = String::from("INSERT INTO standard1 (key");
+        for column in settings.column.columns.iter() {
+            statement_str += &format!(", \"{}\"", column);
+        }
+        statement_str += ") VALUES (?";
+        for _ in settings.column.columns.iter() {
+            statement_str += ", ?";
+        }
+        statement_str.push(')');
+
         let mut statement = session
             .prepare(statement_str)
             .await

--- a/src/bin/cql-stress-cassandra-stress/settings/cs_args_bad_test.in
+++ b/src/bin/cql-stress-cassandra-stress/settings/cs_args_bad_test.in
@@ -20,3 +20,5 @@ cassandra-stress write -col size=FIXED(1..10)
 cassandra-stress write -col size=UNIFORM(50)
 cassandra-stress write -col size=SEQ(1..10,50)
 cassandra-stress write -col names=foo,bar,baz n=3
+cassandra-stress write -pop dist=foo
+cassandra-stress write -pop dist=SEQ(1..10,50)

--- a/src/bin/cql-stress-cassandra-stress/settings/cs_args_bad_test.in
+++ b/src/bin/cql-stress-cassandra-stress/settings/cs_args_bad_test.in
@@ -16,3 +16,7 @@ cassandra-stress read -schema replication(factor=1,=)
 cassandra-stress counter_write cl=QUORUM duration=20m -schema 'replication(strategy=NetworkTopologyStrategy,replication_factor=3)' no-warmup
 cassandra-stress write -rate keyspace=keyspace2
 cassandra-stress counter_write no-warmup cl=ALL duration=20m -schema replication(replication_factor=3) keyspace=keyspace2 -node shard-connection-count=0
+cassandra-stress write -col size=FIXED(1..10)
+cassandra-stress write -col size=UNIFORM(50)
+cassandra-stress write -col size=SEQ(1..10,50)
+cassandra-stress write -col names=foo,bar,baz n=3

--- a/src/bin/cql-stress-cassandra-stress/settings/cs_args_good_test.in
+++ b/src/bin/cql-stress-cassandra-stress/settings/cs_args_good_test.in
@@ -26,3 +26,5 @@ cassandra-stress counter_write no-warmup cl=ALL duration=20m -schema replication
 cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1) -rate threads=10 -col n=10 size=UNIFORM(1..20)
 cassandra-stress read cl=QUORUM n=10000 -schema replication(key=value) -rate threads=10 -col names=foo,bar,baz
 cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1, key=value) -rate threads=10 -col size=FIXED(50)
+cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1, key=value) -rate threads=10 -col size=FIXED(50) -pop dist=SEQ(1..10)
+cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1, key=value) -rate threads=10 -col size=FIXED(50) -pop dist=UNIFORM(1..10)

--- a/src/bin/cql-stress-cassandra-stress/settings/cs_args_good_test.in
+++ b/src/bin/cql-stress-cassandra-stress/settings/cs_args_good_test.in
@@ -23,3 +23,6 @@ cassandra-stress counter_write no-warmup cl=THREE duration=20m -schema keyspace=
 cassandra-stress counter_write no-warmup cl=ANY duration=20m -schema replication(strategy=NetworkTopologyStrategy) keyspace=keyspace2
 cassandra-stress counter_write no-warmup cl=ALL duration=20m -schema replication(replication_factor=3) keyspace=keyspace2
 cassandra-stress counter_write no-warmup cl=ALL duration=20m -schema replication(replication_factor=3) keyspace=keyspace2 -node shard-connection-count=5
+cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1) -rate threads=10 -col n=10 size=UNIFORM(1..20)
+cassandra-stress read cl=QUORUM n=10000 -schema replication(key=value) -rate threads=10 -col names=foo,bar,baz
+cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1, key=value) -rate threads=10 -col size=FIXED(50)

--- a/src/bin/cql-stress-cassandra-stress/settings/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/mod.rs
@@ -19,6 +19,7 @@ use crate::settings::command::print_help;
 use self::command::parse_command;
 use self::option::ColumnOption;
 use self::option::NodeOption;
+use self::option::PopulationOption;
 use self::option::RateOption;
 use self::option::SchemaOption;
 
@@ -29,6 +30,7 @@ pub struct CassandraStressSettings {
     pub rate: RateOption,
     pub schema: SchemaOption,
     pub column: ColumnOption,
+    pub population: PopulationOption,
 }
 
 impl CassandraStressSettings {
@@ -39,6 +41,7 @@ impl CassandraStressSettings {
         self.node.print_settings();
         self.schema.print_settings();
         self.column.print_settings();
+        self.population.print_settings();
         println!();
     }
 }
@@ -155,6 +158,14 @@ where
         let schema = SchemaOption::parse(&mut payload)?;
         let column = ColumnOption::parse(&mut payload)?;
 
+        // The default distribution (if not specified) is SEQ(1..operation_count).
+        // If operation_count is not specified, then the default is 1M.
+        let operation_count = command_params
+            .basic_params
+            .operation_count
+            .map_or(String::from("1000000"), |op| format!("{op}"));
+        let population = PopulationOption::parse(&mut payload, &operation_count)?;
+
         // List the unknown options along with their parameters.
         let build_unknown_arguments_err_message = || -> String {
             let unknowns = payload
@@ -183,6 +194,7 @@ where
                 rate,
                 schema,
                 column,
+                population,
             },
         )))
     };

--- a/src/bin/cql-stress-cassandra-stress/settings/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/mod.rs
@@ -17,6 +17,7 @@ use regex::Regex;
 use crate::settings::command::print_help;
 
 use self::command::parse_command;
+use self::option::ColumnOption;
 use self::option::NodeOption;
 use self::option::RateOption;
 use self::option::SchemaOption;
@@ -27,6 +28,7 @@ pub struct CassandraStressSettings {
     pub node: NodeOption,
     pub rate: RateOption,
     pub schema: SchemaOption,
+    pub column: ColumnOption,
 }
 
 impl CassandraStressSettings {
@@ -36,6 +38,7 @@ impl CassandraStressSettings {
         self.rate.print_settings();
         self.node.print_settings();
         self.schema.print_settings();
+        self.column.print_settings();
         println!();
     }
 }
@@ -150,6 +153,7 @@ where
         let node = NodeOption::parse(&mut payload)?;
         let rate = RateOption::parse(&mut payload)?;
         let schema = SchemaOption::parse(&mut payload)?;
+        let column = ColumnOption::parse(&mut payload)?;
 
         // List the unknown options along with their parameters.
         let build_unknown_arguments_err_message = || -> String {
@@ -178,6 +182,7 @@ where
                 node,
                 rate,
                 schema,
+                column,
             },
         )))
     };

--- a/src/bin/cql-stress-cassandra-stress/settings/option/column.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/option/column.rs
@@ -1,0 +1,126 @@
+use anyhow::Result;
+
+use crate::{
+    java_generate::distribution::DistributionFactory,
+    settings::{
+        param::{types::CommaDelimitedList, ParamsParser, SimpleParamHandle},
+        ParsePayload,
+    },
+};
+
+pub struct ColumnOption {
+    pub columns: Vec<String>,
+    pub size_distribution: Box<dyn DistributionFactory>,
+}
+
+impl ColumnOption {
+    pub const CLI_STRING: &str = "-col";
+
+    pub fn description() -> &'static str {
+        "Column details such as size distribution, names"
+    }
+
+    pub fn parse(cl_args: &mut ParsePayload) -> Result<Self> {
+        let params = cl_args.remove(Self::CLI_STRING).unwrap_or_default();
+        let (parser, handles) = prepare_parser();
+        parser.parse(params)?;
+        Ok(Self::from_handles(handles))
+    }
+
+    pub fn print_help() {
+        let (parser, _) = prepare_parser();
+        parser.print_help();
+    }
+
+    pub fn print_settings(&self) {
+        println!("Column:");
+        println!("  Column names: {:?}", self.columns);
+        println!("  Size distribution: {}", self.size_distribution);
+    }
+
+    fn from_handles(handles: ColumnParamHandles) -> Self {
+        let names = handles.names.get();
+        let columns_count = handles.columns_count.get();
+        let size_distribution = handles.size_distribution.get().unwrap();
+
+        let columns = match names {
+            Some(names) => names,
+            None => (0..columns_count.unwrap())
+                .map(|n| format!("C{n}"))
+                .collect(),
+        };
+
+        Self {
+            columns,
+            size_distribution,
+        }
+    }
+}
+
+struct ColumnParamHandles {
+    names: SimpleParamHandle<CommaDelimitedList>,
+    columns_count: SimpleParamHandle<u64>,
+    size_distribution: SimpleParamHandle<Box<dyn DistributionFactory>>,
+}
+
+fn prepare_parser() -> (ParamsParser, ColumnParamHandles) {
+    let mut parser = ParamsParser::new(ColumnOption::CLI_STRING);
+
+    let names = parser.simple_param("names=", None, "Column names", true);
+    let columns_count = parser.simple_param("n=", Some("5"), "Number of columns", false);
+    let size_distribution =
+        parser.distribution_param("size=", Some("fixed(34)"), "Cell size distribution", false);
+
+    // $ ./cassandra-stress help -col
+    // Usage: -col [n=?] [size=DIST(?)]
+    //  OR
+    // Usage: -col names=? [size=DIST(?)]
+    parser.group(&[&names, &size_distribution]);
+    parser.group(&[&columns_count, &size_distribution]);
+
+    (
+        parser,
+        ColumnParamHandles {
+            names,
+            columns_count,
+            size_distribution,
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ColumnOption;
+
+    use super::prepare_parser;
+
+    #[test]
+    fn col_default_params_test() {
+        let args = vec![];
+        let (parser, handles) = prepare_parser();
+
+        assert!(parser.parse(args).is_ok());
+
+        let params = ColumnOption::from_handles(handles);
+        assert_eq!(&["C0", "C1", "C2", "C3", "C4"], params.columns.as_slice());
+    }
+
+    #[test]
+    fn col_names_params_test() {
+        let args = vec!["names=foo,bar,baz"];
+        let (parser, handles) = prepare_parser();
+
+        assert!(parser.parse(args).is_ok());
+
+        let params = ColumnOption::from_handles(handles);
+        assert_eq!(&["foo", "bar", "baz"], params.columns.as_slice());
+    }
+
+    #[test]
+    fn col_bad_params_test() {
+        let args = vec!["names=foo,bar,baz", "n=10"];
+        let (parser, _) = prepare_parser();
+
+        assert!(parser.parse(args).is_err());
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/settings/option/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/option/mod.rs
@@ -1,9 +1,11 @@
+mod column;
 mod node;
 mod rate;
 mod schema;
 
 use anyhow::Result;
 
+pub use column::ColumnOption;
 pub use node::NodeOption;
 pub use rate::RateOption;
 pub use rate::ThreadsInfo;
@@ -17,6 +19,7 @@ impl Options {
             (NodeOption::CLI_STRING, NodeOption::description()),
             (RateOption::CLI_STRING, RateOption::description()),
             (SchemaOption::CLI_STRING, SchemaOption::description()),
+            (ColumnOption::CLI_STRING, ColumnOption::description()),
         ]
         .into_iter()
     }
@@ -33,6 +36,7 @@ impl Options {
             NodeOption::CLI_STRING => NodeOption::print_help(),
             RateOption::CLI_STRING => RateOption::print_help(),
             SchemaOption::CLI_STRING => SchemaOption::print_help(),
+            ColumnOption::CLI_STRING => ColumnOption::print_help(),
             _ => return Err(anyhow::anyhow!("Invalid option provided to command help")),
         }
 

--- a/src/bin/cql-stress-cassandra-stress/settings/option/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/option/mod.rs
@@ -1,5 +1,6 @@
 mod column;
 mod node;
+mod population;
 mod rate;
 mod schema;
 
@@ -7,6 +8,7 @@ use anyhow::Result;
 
 pub use column::ColumnOption;
 pub use node::NodeOption;
+pub use population::PopulationOption;
 pub use rate::RateOption;
 pub use rate::ThreadsInfo;
 pub use schema::SchemaOption;
@@ -20,6 +22,10 @@ impl Options {
             (RateOption::CLI_STRING, RateOption::description()),
             (SchemaOption::CLI_STRING, SchemaOption::description()),
             (ColumnOption::CLI_STRING, ColumnOption::description()),
+            (
+                PopulationOption::CLI_STRING,
+                PopulationOption::description(),
+            ),
         ]
         .into_iter()
     }
@@ -37,6 +43,7 @@ impl Options {
             RateOption::CLI_STRING => RateOption::print_help(),
             SchemaOption::CLI_STRING => SchemaOption::print_help(),
             ColumnOption::CLI_STRING => ColumnOption::print_help(),
+            PopulationOption::CLI_STRING => PopulationOption::print_help(),
             _ => return Err(anyhow::anyhow!("Invalid option provided to command help")),
         }
 

--- a/src/bin/cql-stress-cassandra-stress/settings/option/population.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/option/population.rs
@@ -1,0 +1,88 @@
+use anyhow::Result;
+
+use crate::{
+    java_generate::distribution::DistributionFactory,
+    settings::{
+        param::{ParamsParser, SimpleParamHandle},
+        ParsePayload,
+    },
+};
+
+pub struct PopulationOption {
+    pub pk_seed_distribution: Box<dyn DistributionFactory>,
+}
+
+impl PopulationOption {
+    pub const CLI_STRING: &str = "-pop";
+
+    pub fn description() -> &'static str {
+        "Population distribution"
+    }
+
+    pub fn parse(cl_args: &mut ParsePayload, operation_count: &str) -> Result<Self> {
+        let params = cl_args.remove(Self::CLI_STRING).unwrap_or_default();
+        let (parser, handles) = prepare_parser(operation_count);
+        parser.parse(params)?;
+        Ok(Self::from_handles(handles))
+    }
+
+    pub fn print_help() {
+        let (parser, _) = prepare_parser("1000000");
+        parser.print_help();
+    }
+
+    pub fn print_settings(&self) {
+        println!("Population:");
+        println!(
+            "  Partition key seed distribution: {}",
+            self.pk_seed_distribution
+        );
+    }
+
+    fn from_handles(handles: PopulationParamHandles) -> Self {
+        let pk_seed_distribution = handles.pk_seed_distribution.get().unwrap();
+
+        Self {
+            pk_seed_distribution,
+        }
+    }
+}
+
+struct PopulationParamHandles {
+    pk_seed_distribution: SimpleParamHandle<Box<dyn DistributionFactory>>,
+}
+
+fn prepare_parser(operation_count: &str) -> (ParamsParser, PopulationParamHandles) {
+    let mut parser = ParamsParser::new(PopulationOption::CLI_STRING);
+
+    let pk_seed_distribution = parser.distribution_param(
+        "dist=",
+        Some(&format!("seq(1..{operation_count})")),
+        "Seeds are selected from this distribution. By default the distribution is seq(1..N) where N is operation count if specified, 1000000 otherwise.",
+        false,
+    );
+
+    // $ ./cassandra-stress help -pop
+    // Usage: -pop [dist=DIST(?)]
+    parser.group(&[&pk_seed_distribution]);
+
+    (
+        parser,
+        PopulationParamHandles {
+            pk_seed_distribution,
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::prepare_parser;
+
+    #[test]
+    fn pop_default_params_test() {
+        let args = vec![];
+        let (parser, _) = prepare_parser("100");
+
+        assert!(parser.parse(args).is_ok());
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/settings/option/schema.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/option/schema.rs
@@ -112,10 +112,15 @@ impl SchemaOption {
         &self,
         table_name: &'static str,
         column_type: &'static str,
+        column_names: &[String],
     ) -> String {
         // Note that for now we hardcode the columns.
         // In the future, `-col` option will be supported, that lets the user define column names as well as the number of columns.
-        let mut result = format!("CREATE TABLE IF NOT EXISTS {0} (key blob, \"C0\" {1}, \"C1\" {1}, \"C2\" {1}, \"C3\" {1}, \"C4\" {1}, PRIMARY KEY (key))", table_name, column_type);
+        let mut result = format!("CREATE TABLE IF NOT EXISTS {0} (key blob", table_name);
+        for column in column_names {
+            result += &format!(", \"{}\" {}", column, column_type);
+        }
+        result += ", PRIMARY KEY (key))";
         result += " WITH compression = {";
         if let Some(compression) = &self.compression {
             result += &format!("'sstable_compression': '{}'", compression);
@@ -128,12 +133,12 @@ impl SchemaOption {
         result
     }
 
-    pub fn construct_table_creation_query(&self) -> String {
-        self.construct_table_creation_query_with("standard1", "blob")
+    pub fn construct_table_creation_query(&self, column_names: &[String]) -> String {
+        self.construct_table_creation_query_with("standard1", "blob", column_names)
     }
 
-    pub fn construct_counter_table_creation_query(&self) -> String {
-        self.construct_table_creation_query_with("counter1", "counter")
+    pub fn construct_counter_table_creation_query(&self, column_names: &[String]) -> String {
+        self.construct_table_creation_query_with("counter1", "counter", column_names)
     }
 }
 

--- a/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
@@ -28,7 +28,7 @@ pub trait ParamImpl {
         &self,
         param_name: &'static str,
         description: &'static str,
-        default_value: Option<&'static str>,
+        default_value: Option<&str>,
     );
 }
 
@@ -47,7 +47,7 @@ pub struct TypedParam<P: ParamImpl> {
     param: P,
     prefix: &'static str,
     desc: &'static str,
-    default: Option<&'static str>,
+    default: Option<String>,
     required: bool,
     supplied_by_user: bool,
     satisfied: bool,
@@ -58,14 +58,14 @@ impl<P: ParamImpl> TypedParam<P> {
         param: P,
         prefix: &'static str,
         desc: &'static str,
-        default: Option<&'static str>,
+        default: Option<&str>,
         required: bool,
     ) -> Self {
         Self {
             param,
             prefix,
             desc,
-            default,
+            default: default.map(|d| d.to_owned()),
             required,
             supplied_by_user: false,
             satisfied: false,
@@ -124,7 +124,8 @@ impl<P: ParamImpl> GenericParam for TypedParam<P> {
     }
 
     fn print_desc(&self) {
-        self.param.print_desc(self.prefix, self.desc, self.default)
+        self.param
+            .print_desc(self.prefix, self.desc, self.default.as_deref())
     }
 
     fn parse(&mut self, arg: &str) -> Result<()> {

--- a/src/bin/cql-stress-cassandra-stress/settings/param/multi_param.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/multi_param.rs
@@ -202,7 +202,7 @@ impl<A: ArbitraryParamsAcceptance> ParamImpl for MultiParam<A> {
         &self,
         param_name: &'static str,
         description: &'static str,
-        _default_value: Option<&'static str>,
+        _default_value: Option<&str>,
     ) {
         print!("{}(", param_name);
         for param in self.subparams.iter() {

--- a/src/bin/cql-stress-cassandra-stress/settings/param/parser.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/parser.rs
@@ -102,7 +102,7 @@ impl ParamsParser {
         required: bool,
     ) -> SimpleParamHandle<T> {
         let param = Rc::new(RefCell::new(SimpleParam::new_wrapped(
-            prefix, default, desc, required,
+            prefix, default, desc, None, required,
         )));
 
         self.params.push(Rc::clone(&param) as ParamCell);
@@ -121,7 +121,7 @@ impl ParamsParser {
         required: bool,
     ) -> SimpleParamHandle<T> {
         let param = Rc::new(RefCell::new(SimpleParam::new_wrapped(
-            prefix, default, desc, required,
+            prefix, default, desc, None, required,
         )));
 
         SimpleParamHandle::new(param)

--- a/src/bin/cql-stress-cassandra-stress/settings/param/parser.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/parser.rs
@@ -102,7 +102,7 @@ impl ParamsParser {
     pub fn simple_param<T: Parsable + 'static>(
         &mut self,
         prefix: &'static str,
-        default: Option<&'static str>,
+        default: Option<&str>,
         desc: &'static str,
         required: bool,
     ) -> SimpleParamHandle<T> {
@@ -121,7 +121,7 @@ impl ParamsParser {
     pub fn simple_subparam<T: Parsable + 'static>(
         &mut self,
         prefix: &'static str,
-        default: Option<&'static str>,
+        default: Option<&str>,
         desc: &'static str,
         required: bool,
     ) -> SimpleParamHandle<T> {
@@ -155,7 +155,7 @@ impl ParamsParser {
     pub fn distribution_param(
         &mut self,
         prefix: &'static str,
-        default: Option<&'static str>,
+        default: Option<&str>,
         desc: &'static str,
         required: bool,
     ) -> SimpleParamHandle<Box<dyn DistributionFactory>> {

--- a/src/bin/cql-stress-cassandra-stress/settings/param/parser.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/parser.rs
@@ -1,6 +1,11 @@
 use anyhow::Result;
 use std::{cell::RefCell, rc::Rc};
 
+use crate::java_generate::distribution::{
+    fixed::FixedDistributionFactory, sequence::SeqDistributionFactory,
+    uniform::UniformDistributionFactory, DistributionFactory,
+};
+
 use super::{
     multi_param::{ArbitraryParamsAcceptance, MultiParam},
     simple_param::{SimpleParam, SimpleParamHandle},
@@ -145,6 +150,41 @@ impl ParamsParser {
 
         self.params.push(Rc::clone(&param) as ParamCell);
         MultiParamHandle::new(param)
+    }
+
+    pub fn distribution_param(
+        &mut self,
+        prefix: &'static str,
+        default: Option<&'static str>,
+        desc: &'static str,
+        required: bool,
+    ) -> SimpleParamHandle<Box<dyn DistributionFactory>> {
+        lazy_static! {
+            static ref DISTRIBUTION_ADDITIONAL_DESCRIPTION: String = {
+                // List available distributions.
+                let lines = [
+                    "    Available distributions:",
+                    &FixedDistributionFactory::help_description(),
+                    &SeqDistributionFactory::help_description(),
+                    &UniformDistributionFactory::help_description(),
+                    "",
+                    "    Preceding the name with ~ will invert the distribution.",
+                ];
+
+                lines.join("\n")
+            };
+        }
+
+        let param = Rc::new(RefCell::new(SimpleParam::new_wrapped(
+            prefix,
+            default,
+            desc,
+            Some(&DISTRIBUTION_ADDITIONAL_DESCRIPTION),
+            required,
+        )));
+
+        self.params.push(Rc::clone(&param) as ParamCell);
+        SimpleParamHandle::new(param)
     }
 
     /// Creates a new group of the parameters.

--- a/src/bin/cql-stress-cassandra-stress/settings/param/simple_param.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/simple_param.rs
@@ -22,7 +22,7 @@ pub struct SimpleParam<T: Parsable> {
 impl<T: Parsable> SimpleParam<T> {
     pub fn new_wrapped(
         prefix: &'static str,
-        default: Option<&'static str>,
+        default: Option<&str>,
         desc: &'static str,
         additional_desc: Option<&str>,
         required: bool,
@@ -59,7 +59,7 @@ impl<T: Parsable> ParamImpl for SimpleParam<T> {
         &self,
         param_name: &'static str,
         description: &'static str,
-        default_value: Option<&'static str>,
+        default_value: Option<&str>,
     ) {
         let mut usage = String::from(param_name);
         if !T::is_bool() {

--- a/src/bin/cql-stress-cassandra-stress/settings/param/simple_param.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/simple_param.rs
@@ -16,6 +16,7 @@ use super::{types::Parsable, ParamCell, ParamHandle, ParamImpl, TypedParam};
 /// - value_pattern := r"^[0-9]+[bmk]?$". It's provided by [super::types::Count].
 pub struct SimpleParam<T: Parsable> {
     value: Option<T::Parsed>,
+    additional_desc: Option<String>,
 }
 
 impl<T: Parsable> SimpleParam<T> {
@@ -23,11 +24,13 @@ impl<T: Parsable> SimpleParam<T> {
         prefix: &'static str,
         default: Option<&'static str>,
         desc: &'static str,
+        additional_desc: Option<&str>,
         required: bool,
     ) -> TypedParam<Self> {
         let param = Self {
             // SAFETY: The default value must be successfully parsed.
             value: default.map(|d| T::parse(d).unwrap()),
+            additional_desc: additional_desc.map(|desc| desc.to_owned()),
         };
 
         TypedParam::new(param, prefix, desc, default, required)
@@ -66,6 +69,9 @@ impl<T: Parsable> ParamImpl for SimpleParam<T> {
             usage += &format!(" (default={default})");
         }
         println!("{:<40} {}", usage, description);
+        if let Some(additional_description) = &self.additional_desc {
+            println!("{additional_description}")
+        }
     }
 }
 

--- a/src/bin/cql-stress-cassandra-stress/settings/param/types.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/types.rs
@@ -4,7 +4,8 @@ use anyhow::{Context, Result};
 use cql_stress::distribution::{parse_description, SyntaxFlavor};
 
 use crate::java_generate::distribution::{
-    fixed::FixedDistributionFactory, sequence::SeqDistributionFactory, DistributionFactory,
+    fixed::FixedDistributionFactory, sequence::SeqDistributionFactory,
+    uniform::UniformDistributionFactory, DistributionFactory,
 };
 
 pub trait Parsable: Sized {
@@ -208,6 +209,7 @@ impl Parsable for Box<dyn DistributionFactory> {
         match description.name {
             "fixed" => FixedDistributionFactory::parse_from_description(description),
             "seq" => SeqDistributionFactory::parse_from_description(description),
+            "uniform" => UniformDistributionFactory::parse_from_description(description),
             _ => Err(anyhow::anyhow!(
                 "Invalid distribution name: {}",
                 description.name
@@ -260,6 +262,28 @@ mod tests {
             "seq(45)",
             "seq(100.1234)",
             "seq40)",
+        ];
+
+        for input in bad_test_cases {
+            assert!(DistributionTestType::parse(input).is_err());
+        }
+    }
+
+    #[test]
+    fn distribution_param_uniform_test() {
+        let good_test_cases = &["uniform(45..50)", "uniform(1..100000)", "uniform(2..2)"];
+        for input in good_test_cases {
+            assert!(DistributionTestType::parse(input).is_ok());
+        }
+
+        let bad_test_cases = &[
+            "uniform(2..1)",
+            "uniform(1..20,50)",
+            "uniform(45",
+            "uniform45..50",
+            "uniform(45)",
+            "uniform(100.1234)",
+            "uniform40)",
         ];
 
         for input in bad_test_cases {


### PR DESCRIPTION
# Changes
- Refactored the `Param` trait, by extracting most of the common logic to the wrapping type
- introduced `DistributionParam`
- implemented parsing logic for `-col` option
- implemented parsing logic for `-pop` option