### PR TITLE
treewide: clippy fixes

### DIFF
--- a/src/bin/cql-stress-cassandra-stress/settings/test.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/test.rs
@@ -51,7 +51,7 @@ fn cs_args_bad_test() {
 
 #[test]
 fn repair_params_test() {
-    let args = vec![
+    let args = [
         "write",
         "-schema replication ( factor = 3 , foo = bar )\t \tkeyspace=k ",
         " compression = someCompressionAlgorithm",

--- a/src/bin/cql-stress-scylla-bench/operation/mod.rs
+++ b/src/bin/cql-stress-scylla-bench/operation/mod.rs
@@ -13,7 +13,7 @@ use tracing::error;
 const GENERATED_DATA_HEADER_SIZE: usize = 24;
 const GENERATED_DATA_MIN_SIZE: usize = GENERATED_DATA_HEADER_SIZE + 33;
 
-pub(self) fn generate_row_data(pk: i64, ck: i64, size: usize) -> Vec<u8> {
+fn generate_row_data(pk: i64, ck: i64, size: usize) -> Vec<u8> {
     if size == 0 {
         Vec::new()
     } else if size < GENERATED_DATA_HEADER_SIZE {
@@ -49,7 +49,7 @@ pub(self) fn generate_row_data(pk: i64, ck: i64, size: usize) -> Vec<u8> {
     }
 }
 
-pub(self) fn validate_row_data(pk: i64, ck: i64, data: &[u8]) -> Result<()> {
+fn validate_row_data(pk: i64, ck: i64, data: &[u8]) -> Result<()> {
     let size = data.len();
     let original_data = data;
 
@@ -120,7 +120,7 @@ pub(self) fn validate_row_data(pk: i64, ck: i64, data: &[u8]) -> Result<()> {
     Ok(())
 }
 
-pub(self) fn validate_counter_row_data(
+fn validate_counter_row_data(
     pk: i64,
     ck: i64,
     c1: i64,


### PR DESCRIPTION
# Motivation
The version of clippy just got bumped, and so new lints were introduced. This PR fixes the failing checks for cql-stress.

# Changes
- replaced unnecessary `vec!` with an array in the test
- removed unnecessary `pub(self)` identifiers in s-b operation module