### PR TITLE
c-s: benchmark statistics

### DIFF
--- a/src/bin/cql-stress-cassandra-stress/main.rs
+++ b/src/bin/cql-stress-cassandra-stress/main.rs
@@ -144,7 +144,7 @@ async fn create_operation_factory(
             WriteOperationFactory::new(settings, session, workload_factory, stats).await?,
         )),
         Command::Read => Ok(Arc::new(
-            ReadOperationFactory::new(settings, session, workload_factory).await?,
+            ReadOperationFactory::new(settings, session, workload_factory, stats).await?,
         )),
         cmd => Err(anyhow::anyhow!(
             "Runtime for command '{}' not implemented yet.",

--- a/src/bin/cql-stress-cassandra-stress/main.rs
+++ b/src/bin/cql-stress-cassandra-stress/main.rs
@@ -4,6 +4,7 @@ extern crate async_trait;
 mod java_generate;
 mod operation;
 mod settings;
+mod stats;
 
 #[macro_use]
 extern crate lazy_static;

--- a/src/bin/cql-stress-cassandra-stress/stats.rs
+++ b/src/bin/cql-stress-cassandra-stress/stats.rs
@@ -1,0 +1,113 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use cql_stress::{configuration::OperationContext, sharded_stats};
+use hdrhistogram::Histogram;
+use tokio::time::Instant;
+
+use crate::settings::{CassandraStressSettings, ThreadsInfo};
+
+/// An interface for latency calculation logic.
+/// c-s can display either raw or coordinated-omission-fixed latencies.
+trait LatencyCalculator: Send + Sync {
+    fn calculate(&self, ctx: &OperationContext) -> u64;
+}
+
+struct RawLatencyCalculator;
+struct CoordinatedOmissionFixedLatencyCalculator;
+
+impl LatencyCalculator for RawLatencyCalculator {
+    fn calculate(&self, ctx: &OperationContext) -> u64 {
+        let now = Instant::now();
+        (now - ctx.actual_start_time).as_nanos() as u64
+    }
+}
+
+impl LatencyCalculator for CoordinatedOmissionFixedLatencyCalculator {
+    fn calculate(&self, ctx: &OperationContext) -> u64 {
+        let now = Instant::now();
+        (now - ctx.scheduled_start_time).as_nanos() as u64
+    }
+}
+
+pub type ShardedStats = sharded_stats::ShardedStats<StatsFactory>;
+
+pub struct StatsFactory {
+    coordinated_omission_fixed: bool,
+}
+
+pub struct Stats {
+    operations: u64,
+    errors: u64,
+    latency_calculator: Box<dyn LatencyCalculator>,
+    latency_histogram: Histogram<u64>,
+}
+
+impl StatsFactory {
+    pub fn new(settings: &Arc<CassandraStressSettings>) -> Self {
+        let coordinated_omission_fixed = match settings.rate.threads_info {
+            ThreadsInfo::Fixed {
+                threads: _,
+                throttle: _,
+                co_fixed,
+            } => co_fixed,
+            ThreadsInfo::Auto { .. } => false,
+        };
+
+        Self {
+            coordinated_omission_fixed,
+        }
+    }
+}
+
+impl sharded_stats::StatsFactory for StatsFactory {
+    type Stats = Stats;
+
+    fn create(&self) -> Self::Stats {
+        Stats {
+            operations: 0,
+            errors: 0,
+            // This cannot panic since 1 <= sigfig <= 5.
+            // 3 is the recommended value, as well as used in Java's c-s implementation.
+            // AFAIK, there is no c-s option which lets the user define this value.
+            latency_histogram: Histogram::new(3).unwrap(),
+            latency_calculator: if self.coordinated_omission_fixed {
+                Box::new(CoordinatedOmissionFixedLatencyCalculator)
+            } else {
+                Box::new(RawLatencyCalculator)
+            },
+        }
+    }
+}
+
+impl Stats {
+    pub fn account_operation<T, E>(&mut self, ctx: &OperationContext, result: &Result<T, E>) {
+        self.operations += 1;
+        match result {
+            Ok(_) => {
+                self.latency_histogram
+                    .record(self.latency_calculator.calculate(ctx))
+                    .unwrap();
+            }
+            Err(_) => {
+                self.errors += 1;
+            }
+        }
+    }
+}
+
+impl sharded_stats::Stats for Stats {
+    fn clear(&mut self) {
+        self.operations = 0;
+        self.errors = 0;
+        self.latency_histogram.reset();
+    }
+
+    fn combine(&mut self, other: &Self) {
+        self.operations += other.operations;
+        self.errors += other.errors;
+        self.latency_histogram
+            .add(&other.latency_histogram)
+            .unwrap();
+    }
+}


### PR DESCRIPTION
# Motivation

Since the basic runtime routines have already been implemented, we should display some statistics during the benchmark. This PR introduces a `stats` module responsible for collecting and printing formatted statistics.

# Changes
- Introduced `stats` module with:
  - `Stats` structure implementing `cql_stress::sharded_stats::Stats`
  - `StatsFactory` structure implementing `cql_stress::sharded_stats::StatsFactory`
  - `LatencyCalculator` trait with two implementations - one calculating raw latencies (`end` - `start`), and the other calculating [coordinated-omission-fixed](https://www.scylladb.com/2021/04/22/on-coordinated-omission/) latencies (`end` - `scheduled_start`). This trait is used by `Stats` structure to keep track of the recorded latencies, based on the type of the latency provided by the user (`-rate fixed` CLI boolean flag).
  - `StatsPrinter` structure responsible for displaying formatted benchmark statistics
- Adjusted `Read/WriteOperation` to record the results of the operations to the `Stats` structure
- Extended `main` logic to display formatted statistics periodically. By default, the display interval is 1 second - for now it's hardcoded but left as a TODO to adjust when `-log` option (`interval` parameter) is supported. 