### PR TITLE
c-s: params wrapper

### DIFF
--- a/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
@@ -12,13 +12,8 @@ pub use multi_param::MultiParamHandle;
 pub use parser::ParamsParser;
 pub use simple_param::SimpleParamHandle;
 
-/// An 'interface' of parameter.
-///
-/// Note that the parser uses trait objects.
-/// For now, it may seem to be unnecessary since we only support `SimpleParam`s.
-/// However, cassandra-stress supports more complex parameters (see help -schema)
-/// which cql-stress should support in the future as well.
-pub trait Param {
+/// A specific implementation of the parameter.
+pub trait ParamImpl {
     /// Checks whether `arg` matches parameter's prefix.
     fn try_match(&self, arg: &str) -> bool;
     /// Parses the `arg` value.
@@ -40,7 +35,7 @@ pub trait Param {
     fn print_desc(&self);
 }
 
-type ParamCell = Rc<RefCell<dyn Param>>;
+type ParamCell = Rc<RefCell<dyn ParamImpl>>;
 
 pub trait ParamHandle {
     fn cell(&self) -> ParamCell;

--- a/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
@@ -16,7 +16,6 @@ pub use simple_param::SimpleParamHandle;
 pub trait ParamImpl {
     /// Parses the `arg` value.
     fn parse(&mut self, arg: &str) -> Result<()>;
-    fn required(&self) -> bool;
     /// Ref: check `ParamsGroup`.
     /// Checking whether the group is satisfied happens right after all of the
     /// CLI arguments were successfully consumed. If the group is satisfied,
@@ -99,7 +98,7 @@ impl<P: ParamImpl> GenericParam for TypedParam<P> {
     }
 
     fn required(&self) -> bool {
-        self.param.required()
+        self.required
     }
 
     fn try_match(&self, arg: &str) -> bool {
@@ -112,7 +111,13 @@ impl<P: ParamImpl> GenericParam for TypedParam<P> {
     }
 
     fn print_usage(&self) {
-        self.param.print_usage()
+        if !self.required {
+            print!("[");
+        }
+        self.param.print_usage();
+        if !self.required {
+            print!("]");
+        }
     }
 
     fn print_desc(&self) {

--- a/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
@@ -29,7 +29,7 @@ pub trait ParamImpl {
     /// Prints the usage format of the parameter.
     fn print_usage(&self, param_name: &'static str);
     /// Prints short description of the parameter.
-    fn print_desc(&self, param_name: &'static str);
+    fn print_desc(&self, param_name: &'static str, description: &'static str);
 }
 
 /// A simple wrapper for specific parameters implementations.
@@ -123,7 +123,7 @@ impl<P: ParamImpl> GenericParam for TypedParam<P> {
     }
 
     fn print_desc(&self) {
-        self.param.print_desc(self.prefix)
+        self.param.print_desc(self.prefix, self.desc)
     }
 
     fn parse(&mut self, arg: &str) -> Result<()> {

--- a/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
@@ -16,8 +16,6 @@ pub use simple_param::SimpleParamHandle;
 pub trait ParamImpl {
     /// Parses the `arg` value.
     fn parse(&mut self, arg: &str) -> Result<()>;
-    /// Tells whether the parameter was parsed with the user-provided argument.
-    fn supplied_by_user(&self) -> bool;
     fn required(&self) -> bool;
     /// Ref: check `ParamsGroup`.
     /// Checking whether the group is satisfied happens right after all of the
@@ -97,7 +95,7 @@ pub trait GenericParam {
 
 impl<P: ParamImpl> GenericParam for TypedParam<P> {
     fn supplied_by_user(&self) -> bool {
-        self.param.supplied_by_user()
+        self.supplied_by_user
     }
 
     fn required(&self) -> bool {
@@ -122,6 +120,12 @@ impl<P: ParamImpl> GenericParam for TypedParam<P> {
     }
 
     fn parse(&mut self, arg: &str) -> Result<()> {
+        anyhow::ensure!(
+            !self.supplied_by_user,
+            "{} suboption has been specified more than once",
+            self.prefix
+        );
+        self.supplied_by_user = true;
         self.param.parse(arg)
     }
 }

--- a/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
@@ -14,8 +14,6 @@ pub use simple_param::SimpleParamHandle;
 
 /// A specific implementation of the parameter.
 pub trait ParamImpl {
-    /// Checks whether `arg` matches parameter's prefix.
-    fn try_match(&self, arg: &str) -> bool;
     /// Parses the `arg` value.
     fn parse(&mut self, arg: &str) -> Result<()>;
     /// Tells whether the parameter was parsed with the user-provided argument.
@@ -107,7 +105,8 @@ impl<P: ParamImpl> GenericParam for TypedParam<P> {
     }
 
     fn try_match(&self, arg: &str) -> bool {
-        self.param.try_match(arg)
+        // Common logic for all types of parameters.
+        arg.starts_with(self.prefix)
     }
 
     fn set_satisfied(&mut self) {

--- a/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
@@ -20,11 +20,7 @@ pub use simple_param::SimpleParamHandle;
 /// which cql-stress should support in the future as well.
 pub trait Param {
     /// Checks whether `arg` matches parameter's prefix.
-    /// Returns:
-    /// - ParamMatchResult::NoMatch if argument doesn't match the prefix
-    /// - ParamMatchResult::Error if argument matches the prefix, but doesn't satisfy the value pattern
-    /// - ParamMatchResult::Match if argument matches both prefix and value pattern.
-    fn try_match(&self, arg: &str) -> ParamMatchResult;
+    fn try_match(&self, arg: &str) -> bool;
     /// Parses the `arg` value.
     fn parse(&mut self, arg: &str) -> Result<()>;
     /// Tells whether the parameter was parsed with the user-provided argument.
@@ -48,9 +44,4 @@ type ParamCell = Rc<RefCell<dyn Param>>;
 
 pub trait ParamHandle {
     fn cell(&self) -> ParamCell;
-}
-pub enum ParamMatchResult {
-    Match,
-    NoMatch,
-    Error(anyhow::Error),
 }

--- a/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
@@ -29,7 +29,12 @@ pub trait ParamImpl {
     /// Prints the usage format of the parameter.
     fn print_usage(&self, param_name: &'static str);
     /// Prints short description of the parameter.
-    fn print_desc(&self, param_name: &'static str, description: &'static str);
+    fn print_desc(
+        &self,
+        param_name: &'static str,
+        description: &'static str,
+        default_value: Option<&'static str>,
+    );
 }
 
 /// A simple wrapper for specific parameters implementations.
@@ -123,7 +128,7 @@ impl<P: ParamImpl> GenericParam for TypedParam<P> {
     }
 
     fn print_desc(&self) {
-        self.param.print_desc(self.prefix, self.desc)
+        self.param.print_desc(self.prefix, self.desc, self.default)
     }
 
     fn parse(&mut self, arg: &str) -> Result<()> {

--- a/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
@@ -18,14 +18,9 @@ pub trait ParamImpl {
     /// Parses the `arg_value'.
     /// Includes `param_name` for building error messages based on the context.
     fn parse(&mut self, param_name: &'static str, arg_value: &str) -> Result<()>;
-    /// Ref: check `ParamsGroup`.
-    /// Checking whether the group is satisfied happens right after all of the
-    /// CLI arguments were successfully consumed. If the group is satisfied,
-    /// it will mark all of its parameters as satisfied as well.
-    /// Then, before returning any value, the parameter will check if its satisfied.
-    /// If it's not, it will return `None`. Note that it's needed in case of parameters
-    /// with default values that don't belong to the satisfied group - otherwise, they would return `Some(_)`.
-    fn set_satisfied(&mut self);
+    /// For some types (i.e. [multi_param::MultiParam]) it's necessary to mark subparameters
+    /// as satisfied. Default implementation does nothing.
+    fn set_subparams_satisfied(&mut self) {}
     /// Prints the usage format of the parameter.
     fn print_usage(&self, param_name: &'static str);
     /// Prints short description of the parameter.
@@ -114,7 +109,8 @@ impl<P: ParamImpl> GenericParam for TypedParam<P> {
     }
 
     fn set_satisfied(&mut self) {
-        self.param.set_satisfied()
+        self.satisfied = true;
+        self.param.set_subparams_satisfied()
     }
 
     fn print_usage(&self) {

--- a/src/bin/cql-stress-cassandra-stress/settings/param/multi_param.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/multi_param.rs
@@ -103,13 +103,12 @@ pub struct MultiParam<A: ArbitraryParamsAcceptance> {
     subparams: Vec<ParamCell>,
     // Arbitrary parameters of the `key=value` form.
     arbitrary_params: A,
-    satisfied: bool,
 }
 
 impl MultiParam<AcceptsArbitraryParams> {
     /// Retrieves arbitrary subparameters (if parsed successfully) and consumes the parameter.
-    pub fn get_arbitrary(self) -> Option<HashMap<String, String>> {
-        self.satisfied.then_some(self.arbitrary_params.map)
+    pub fn get_arbitrary(self) -> HashMap<String, String> {
+        self.arbitrary_params.map
     }
 }
 
@@ -123,7 +122,6 @@ impl<A: ArbitraryParamsAcceptance> MultiParam<A> {
         let param = Self {
             subparams,
             arbitrary_params: Default::default(),
-            satisfied: false,
         };
 
         TypedParam::new(param, prefix, desc, None, required)
@@ -183,8 +181,7 @@ impl<A: ArbitraryParamsAcceptance> ParamImpl for MultiParam<A> {
         Ok(())
     }
 
-    fn set_satisfied(&mut self) {
-        self.satisfied = true;
+    fn set_subparams_satisfied(&mut self) {
         for param in self.subparams.iter() {
             param.borrow_mut().set_satisfied();
         }
@@ -224,7 +221,7 @@ impl<A: ArbitraryParamsAcceptance> ParamImpl for MultiParam<A> {
 
 impl TypedParam<MultiParam<AcceptsArbitraryParams>> {
     fn get_arbitrary(self) -> Option<HashMap<String, String>> {
-        self.param.get_arbitrary()
+        self.satisfied.then_some(self.param.get_arbitrary())
     }
 }
 

--- a/src/bin/cql-stress-cassandra-stress/settings/param/multi_param.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/multi_param.rs
@@ -106,7 +106,6 @@ pub struct MultiParam<A: ArbitraryParamsAcceptance> {
     required: bool,
     // Arbitrary parameters of the `key=value` form.
     arbitrary_params: A,
-    supplied_by_user: bool,
     satisfied: bool,
 }
 
@@ -130,7 +129,6 @@ impl<A: ArbitraryParamsAcceptance> MultiParam<A> {
             desc,
             required,
             arbitrary_params: Default::default(),
-            supplied_by_user: false,
             satisfied: false,
         };
 
@@ -158,13 +156,6 @@ impl<A: ArbitraryParamsAcceptance> MultiParam<A> {
 
 impl<A: ArbitraryParamsAcceptance> ParamImpl for MultiParam<A> {
     fn parse(&mut self, arg: &str) -> Result<()> {
-        anyhow::ensure!(
-            !self.supplied_by_user,
-            "{} suboption has been specified more than once",
-            self.prefix
-        );
-
-        self.supplied_by_user = true;
         let arg_val = &arg[self.prefix.len()..];
 
         // Remove wrapping parenthesis.
@@ -198,10 +189,6 @@ impl<A: ArbitraryParamsAcceptance> ParamImpl for MultiParam<A> {
         }
 
         Ok(())
-    }
-
-    fn supplied_by_user(&self) -> bool {
-        self.supplied_by_user
     }
 
     fn required(&self) -> bool {

--- a/src/bin/cql-stress-cassandra-stress/settings/param/multi_param.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/multi_param.rs
@@ -201,7 +201,12 @@ impl<A: ArbitraryParamsAcceptance> ParamImpl for MultiParam<A> {
         print!("{}(?)", param_name)
     }
 
-    fn print_desc(&self, param_name: &'static str, description: &'static str) {
+    fn print_desc(
+        &self,
+        param_name: &'static str,
+        description: &'static str,
+        _default_value: Option<&'static str>,
+    ) {
         print!("{}(", param_name);
         for param in self.subparams.iter() {
             param.borrow().print_usage();

--- a/src/bin/cql-stress-cassandra-stress/settings/param/multi_param.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/multi_param.rs
@@ -240,10 +240,6 @@ impl<A: ArbitraryParamsAcceptance> ParamImpl for MultiParam<A> {
             param.borrow().print_desc();
         }
     }
-
-    fn try_match(&self, arg: &str) -> bool {
-        arg.starts_with(self.prefix)
-    }
 }
 
 impl TypedParam<MultiParam<AcceptsArbitraryParams>> {

--- a/src/bin/cql-stress-cassandra-stress/settings/param/multi_param.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/multi_param.rs
@@ -101,7 +101,6 @@ pub struct MultiParam<A: ArbitraryParamsAcceptance> {
     // Pre-defined parameters.
     // User can access them via their corresponding handles.
     subparams: Vec<ParamCell>,
-    desc: &'static str,
     // Arbitrary parameters of the `key=value` form.
     arbitrary_params: A,
     satisfied: bool,
@@ -123,7 +122,6 @@ impl<A: ArbitraryParamsAcceptance> MultiParam<A> {
     ) -> TypedParam<Self> {
         let param = Self {
             subparams,
-            desc,
             arbitrary_params: Default::default(),
             satisfied: false,
         };
@@ -203,7 +201,7 @@ impl<A: ArbitraryParamsAcceptance> ParamImpl for MultiParam<A> {
         print!("{}(?)", param_name)
     }
 
-    fn print_desc(&self, param_name: &'static str) {
+    fn print_desc(&self, param_name: &'static str, description: &'static str) {
         print!("{}(", param_name);
         for param in self.subparams.iter() {
             param.borrow().print_usage();
@@ -211,7 +209,7 @@ impl<A: ArbitraryParamsAcceptance> ParamImpl for MultiParam<A> {
         if self.accepts_arbitrary() {
             print!("[<option 1..N>=?]");
         }
-        println!("): {}", self.desc);
+        println!("): {}", description);
         for param in self.subparams.iter() {
             print!("      ");
             param.borrow().print_desc();

--- a/src/bin/cql-stress-cassandra-stress/settings/param/multi_param.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/multi_param.rs
@@ -103,7 +103,6 @@ pub struct MultiParam<A: ArbitraryParamsAcceptance> {
     // User can access them via their corresponding handles.
     subparams: Vec<ParamCell>,
     desc: &'static str,
-    required: bool,
     // Arbitrary parameters of the `key=value` form.
     arbitrary_params: A,
     satisfied: bool,
@@ -127,7 +126,6 @@ impl<A: ArbitraryParamsAcceptance> MultiParam<A> {
             prefix,
             subparams,
             desc,
-            required,
             arbitrary_params: Default::default(),
             satisfied: false,
         };
@@ -189,10 +187,6 @@ impl<A: ArbitraryParamsAcceptance> ParamImpl for MultiParam<A> {
         }
 
         Ok(())
-    }
-
-    fn required(&self) -> bool {
-        self.required
     }
 
     fn set_satisfied(&mut self) {

--- a/src/bin/cql-stress-cassandra-stress/settings/param/multi_param.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/multi_param.rs
@@ -3,7 +3,7 @@ use std::{cell::RefCell, collections::HashMap, rc::Rc};
 use anyhow::Result;
 use regex::Regex;
 
-use super::{Param, ParamCell, ParamHandle};
+use super::{ParamCell, ParamHandle, ParamImpl};
 
 lazy_static! {
     // The arbitrary parameters should match pattern `key=value`.
@@ -154,7 +154,7 @@ impl<A: ArbitraryParamsAcceptance> MultiParam<A> {
     }
 }
 
-impl<A: ArbitraryParamsAcceptance> Param for MultiParam<A> {
+impl<A: ArbitraryParamsAcceptance> ParamImpl for MultiParam<A> {
     fn parse(&mut self, arg: &str) -> Result<()> {
         anyhow::ensure!(
             !self.supplied_by_user,
@@ -276,7 +276,7 @@ impl<A: ArbitraryParamsAcceptance + 'static> ParamHandle for MultiParamHandle<A>
 
 #[cfg(test)]
 mod tests {
-    use crate::settings::param::Param;
+    use crate::settings::param::ParamImpl;
 
     use super::MultiParam;
 

--- a/src/bin/cql-stress-cassandra-stress/settings/param/parser.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/parser.rs
@@ -101,7 +101,7 @@ impl ParamsParser {
         desc: &'static str,
         required: bool,
     ) -> SimpleParamHandle<T> {
-        let param = Rc::new(RefCell::new(SimpleParam::new(
+        let param = Rc::new(RefCell::new(SimpleParam::new_wrapped(
             prefix, default, desc, required,
         )));
 
@@ -120,7 +120,7 @@ impl ParamsParser {
         desc: &'static str,
         required: bool,
     ) -> SimpleParamHandle<T> {
-        let param = Rc::new(RefCell::new(SimpleParam::new(
+        let param = Rc::new(RefCell::new(SimpleParam::new_wrapped(
             prefix, default, desc, required,
         )));
 
@@ -136,7 +136,7 @@ impl ParamsParser {
         desc: &'static str,
         required: bool,
     ) -> MultiParamHandle<A> {
-        let param = Rc::new(RefCell::new(MultiParam::new(
+        let param = Rc::new(RefCell::new(MultiParam::new_wrapped(
             prefix,
             subparams.iter().map(|handle| handle.cell()).collect(),
             desc,

--- a/src/bin/cql-stress-cassandra-stress/settings/param/parser.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/parser.rs
@@ -5,7 +5,7 @@ use super::{
     multi_param::{ArbitraryParamsAcceptance, MultiParam},
     simple_param::{SimpleParam, SimpleParamHandle},
     types::Parsable,
-    MultiParamHandle, ParamCell, ParamHandle, ParamMatchResult,
+    MultiParamHandle, ParamCell, ParamHandle,
 };
 
 /// Some of the parameters are mutually exclusive. For example, we can't do
@@ -166,14 +166,10 @@ impl ParamsParser {
             let mut consumed = false;
             for param in self.params.iter() {
                 let mut borrowed = param.borrow_mut();
-                match borrowed.try_match(arg) {
-                    ParamMatchResult::Error(e) => return Err(e),
-                    ParamMatchResult::NoMatch => (),
-                    ParamMatchResult::Match => {
-                        borrowed.parse(arg)?;
-                        consumed = true;
-                        break;
-                    }
+                if borrowed.try_match(arg) {
+                    borrowed.parse(arg)?;
+                    consumed = true;
+                    break;
                 }
             }
 

--- a/src/bin/cql-stress-cassandra-stress/settings/param/simple_param.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/simple_param.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use anyhow::{Context, Result};
 
-use super::{types::Parsable, Param, ParamCell, ParamHandle};
+use super::{types::Parsable, ParamCell, ParamHandle, ParamImpl};
 
 /// Abstraction of simple parameter which is of the following pattern:
 /// <prefix><value_pattern>
@@ -52,7 +52,7 @@ impl<T: Parsable> SimpleParam<T> {
     }
 }
 
-impl<T: Parsable> Param for SimpleParam<T> {
+impl<T: Parsable> ParamImpl for SimpleParam<T> {
     fn try_match(&self, arg: &str) -> bool {
         arg.starts_with(self.prefix)
     }

--- a/src/bin/cql-stress-cassandra-stress/settings/param/simple_param.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/simple_param.rs
@@ -19,7 +19,6 @@ pub struct SimpleParam<T: Parsable> {
     prefix: &'static str,
     default: Option<&'static str>,
     desc: &'static str,
-    required: bool,
     satisfied: bool,
 }
 
@@ -36,7 +35,6 @@ impl<T: Parsable> SimpleParam<T> {
             prefix,
             default,
             desc,
-            required,
             satisfied: false,
         };
 
@@ -63,24 +61,14 @@ impl<T: Parsable> ParamImpl for SimpleParam<T> {
         Ok(())
     }
 
-    fn required(&self) -> bool {
-        self.required
-    }
-
     fn set_satisfied(&mut self) {
         self.satisfied = true;
     }
 
     fn print_usage(&self) {
-        if !self.required {
-            print!("[");
-        }
         print!("{}", self.prefix);
         if !T::is_bool() {
             print!("?");
-        }
-        if !self.required {
-            print!("]");
         }
     }
 

--- a/src/bin/cql-stress-cassandra-stress/settings/param/simple_param.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/simple_param.rs
@@ -17,7 +17,6 @@ use super::{types::Parsable, ParamCell, ParamHandle, ParamImpl, TypedParam};
 pub struct SimpleParam<T: Parsable> {
     value: Option<T::Parsed>,
     default: Option<&'static str>,
-    desc: &'static str,
     satisfied: bool,
 }
 
@@ -32,7 +31,6 @@ impl<T: Parsable> SimpleParam<T> {
             // SAFETY: The default value must be successfully parsed.
             value: default.map(|d| T::parse(d).unwrap()),
             default,
-            desc,
             satisfied: false,
         };
 
@@ -65,15 +63,15 @@ impl<T: Parsable> ParamImpl for SimpleParam<T> {
         }
     }
 
-    fn print_desc(&self, param_name: &'static str) {
-        let mut desc = String::from(param_name);
+    fn print_desc(&self, param_name: &'static str, description: &'static str) {
+        let mut usage = String::from(param_name);
         if !T::is_bool() {
-            desc.push('?');
+            usage.push('?');
         }
         if let Some(default) = self.default {
-            desc += &format!(" (default={default})");
+            usage += &format!(" (default={default})");
         }
-        println!("{:<40} {}", desc, self.desc);
+        println!("{:<40} {}", usage, description);
     }
 }
 

--- a/src/bin/cql-stress-cassandra-stress/settings/param/simple_param.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/simple_param.rs
@@ -55,10 +55,6 @@ impl<T: Parsable> SimpleParam<T> {
 }
 
 impl<T: Parsable> ParamImpl for SimpleParam<T> {
-    fn try_match(&self, arg: &str) -> bool {
-        arg.starts_with(self.prefix)
-    }
-
     fn parse(&mut self, arg: &str) -> Result<()> {
         anyhow::ensure!(
             !self.supplied_by_user,

--- a/src/bin/cql-stress-cassandra-stress/settings/param/simple_param.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/simple_param.rs
@@ -20,7 +20,6 @@ pub struct SimpleParam<T: Parsable> {
     default: Option<&'static str>,
     desc: &'static str,
     required: bool,
-    supplied_by_user: bool,
     satisfied: bool,
 }
 
@@ -38,7 +37,6 @@ impl<T: Parsable> SimpleParam<T> {
             default,
             desc,
             required,
-            supplied_by_user: false,
             satisfied: false,
         };
 
@@ -56,24 +54,13 @@ impl<T: Parsable> SimpleParam<T> {
 
 impl<T: Parsable> ParamImpl for SimpleParam<T> {
     fn parse(&mut self, arg: &str) -> Result<()> {
-        anyhow::ensure!(
-            !self.supplied_by_user,
-            "{} suboption has been specified more than once",
-            self.prefix
-        );
-
         let arg_val = &arg[self.prefix.len()..];
-        self.supplied_by_user = true;
         self.value = Some(
             T::parse(arg_val)
                 .with_context(|| format!("Failed to parse parameter {}.", self.prefix))?,
         );
 
         Ok(())
-    }
-
-    fn supplied_by_user(&self) -> bool {
-        self.supplied_by_user
     }
 
     fn required(&self) -> bool {

--- a/src/bin/cql-stress-cassandra-stress/settings/param/simple_param.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/simple_param.rs
@@ -16,7 +16,6 @@ use super::{types::Parsable, ParamCell, ParamHandle, ParamImpl, TypedParam};
 /// - value_pattern := r"^[0-9]+[bmk]?$". It's provided by [super::types::Count].
 pub struct SimpleParam<T: Parsable> {
     value: Option<T::Parsed>,
-    default: Option<&'static str>,
     satisfied: bool,
 }
 
@@ -30,7 +29,6 @@ impl<T: Parsable> SimpleParam<T> {
         let param = Self {
             // SAFETY: The default value must be successfully parsed.
             value: default.map(|d| T::parse(d).unwrap()),
-            default,
             satisfied: false,
         };
 
@@ -63,12 +61,17 @@ impl<T: Parsable> ParamImpl for SimpleParam<T> {
         }
     }
 
-    fn print_desc(&self, param_name: &'static str, description: &'static str) {
+    fn print_desc(
+        &self,
+        param_name: &'static str,
+        description: &'static str,
+        default_value: Option<&'static str>,
+    ) {
         let mut usage = String::from(param_name);
         if !T::is_bool() {
             usage.push('?');
         }
-        if let Some(default) = self.default {
+        if let Some(default) = default_value {
             usage += &format!(" (default={default})");
         }
         println!("{:<40} {}", usage, description);


### PR DESCRIPTION
# Motivation

Before the changes, a lot of common logic (and fields) would be repeated in implementations of `Param` trait. I found it annoying when implementing yet another type of parameters (`DistributionParam` - https://github.com/scylladb/cql-stress/pull/48) to repeat the same boilerplate code.

Simple examples:
- `required`, `prefix`, `satisfied`, `desc` fields used by both `SimpleParam` and `MultiParam`
- getters and setters for the fields in `Param` trait - the exact same implementations for both types of parameters
- common parsing logic - e.g. check if user-provided argument starts with `prefix`.

This PR introduces a new generic type `ParamWrapperImpl<P: Param>` which wraps the `Param` implementations. The logic shared between all of the types of parameters is extracted to the wrapping type.

# Changes
- Introduced generic `ParamWrapperImpl<P: Param>` type which wraps the common logic of the parameters
- Introduced `ParamWrapper` trait implemented (once) by all of the generic `ParamWrapperImpl` types. This trait is needed so we can store both `ParamWrapperImpl<SimpleParam>` and `ParamWrapperImpl<MultiParam>` in common collections used by the parser.
- Extracted the shared logic from `Param` implementations to `ParamWrapperImpl`
- Changed `ParamCell` type used by the parser from `Rc<RefCell<dyn Param>>` to `Rc<RefCell<dyn ParamWrapper>>`. Adjusted usages of the type.

# Notes
Please review this PR before https://github.com/scylladb/cql-stress/pull/48, since the options implemented in the mentioned PR base on the changes introduced by this PR.