### PR TITLE
c-s CLI fixups

### DIFF
--- a/src/bin/cql-stress-cassandra-stress/main.rs
+++ b/src/bin/cql-stress-cassandra-stress/main.rs
@@ -34,8 +34,7 @@ async fn main() -> Result<()> {
         .with_env_filter(EnvFilter::try_from_default_env().unwrap_or(EnvFilter::new("warn")))
         .init();
 
-    // Cassandra-stress CLI is case-insensitive.
-    let settings = match parse_cassandra_stress_args(env::args().map(|arg| arg.to_lowercase())) {
+    let settings = match parse_cassandra_stress_args(env::args()) {
         // Special commands: help, print, version
         Ok(CassandraStressParsingResult::SpecialCommand) => return Ok(()),
         Ok(CassandraStressParsingResult::Workload(payload)) => Arc::new(*payload),

--- a/src/bin/cql-stress-cassandra-stress/settings/cs_args_good_test.in
+++ b/src/bin/cql-stress-cassandra-stress/settings/cs_args_good_test.in
@@ -28,3 +28,7 @@ cassandra-stress read cl=QUORUM n=10000 -schema replication(key=value) -rate thr
 cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1, key=value) -rate threads=10 -col size=FIXED(50)
 cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1, key=value) -rate threads=10 -col size=FIXED(50) -pop dist=SEQ(1..10)
 cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1, key=value) -rate threads=10 -col size=FIXED(50) -pop dist=UNIFORM(1..10)
+cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1, key=value) -rate threads=10 -col size=fixed(50) -pop dist=UNIFORM(1..10)
+
+# This tests the case sensitivity of throttle= parameter's value. We should accept both /S and /s.
+cassandra-stress read no-warmup cl=QUORUM duration=600M -rate threads=80 throttle=8000/S

--- a/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/mod.rs
@@ -105,7 +105,7 @@ impl<P: ParamImpl> GenericParam for TypedParam<P> {
 
     fn try_match(&self, arg: &str) -> bool {
         // Common logic for all types of parameters.
-        arg.starts_with(self.prefix)
+        arg.to_lowercase().starts_with(self.prefix)
     }
 
     fn set_satisfied(&mut self) {

--- a/src/bin/cql-stress-cassandra-stress/settings/param/types.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/types.rs
@@ -107,6 +107,7 @@ impl Parsable for Duration {
     type Parsed = Duration;
 
     fn parse(s: &str) -> Result<Self::Parsed> {
+        let s = &s.to_lowercase();
         ensure_regex!(s, r"^[0-9]+[smh]$");
 
         let parse_duration_unit = |unit: char| -> Result<u64> {
@@ -140,6 +141,7 @@ impl Parsable for Count {
     type Parsed = u64;
 
     fn parse(s: &str) -> Result<Self::Parsed> {
+        let s: &str = &s.to_lowercase();
         ensure_regex!(s, r"^[0-9]+[bmk]?$");
 
         let parse_operation_count_unit = |unit: char| -> Result<u64> {
@@ -185,6 +187,7 @@ impl Parsable for Rate {
     type Parsed = u64;
 
     fn parse(s: &str) -> Result<Self::Parsed> {
+        let s = &s.to_lowercase();
         ensure_regex!(s, r"^[0-9]+/s$");
 
         let value_slice = &s[..s.len() - 2];
@@ -199,6 +202,7 @@ impl Parsable for Box<dyn DistributionFactory> {
     type Parsed = Self;
 
     fn parse(s: &str) -> Result<Self::Parsed> {
+        let s = &s.to_lowercase();
         let description = parse_description(s, SyntaxFlavor::Classic)?;
 
         anyhow::ensure!(

--- a/src/bin/cql-stress-cassandra-stress/settings/test.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/test.rs
@@ -13,7 +13,7 @@ fn cs_args_good_test() {
         if input.is_empty() || input.starts_with('#') {
             continue;
         }
-        match parse_cassandra_stress_args(input.to_lowercase().split_ascii_whitespace()) {
+        match parse_cassandra_stress_args(input.split_ascii_whitespace()) {
             Err(_) => {
                 eprintln!("Error on line {}: {}", i + 1, input);
                 failure += 1;
@@ -36,7 +36,7 @@ fn cs_args_bad_test() {
         if input.is_empty() || input.starts_with('#') {
             continue;
         }
-        match parse_cassandra_stress_args(input.to_lowercase().split_ascii_whitespace()) {
+        match parse_cassandra_stress_args(input.split_ascii_whitespace()) {
             Err(_) => failure += 1,
             _ => {
                 eprintln!("Should have failed on line {}: {}", i + 1, input);


### PR DESCRIPTION
# Motivation
During the tests of cql-stress with [SCT](https://github.com/scylladb/scylla-cluster-tests), we noticed that there are some minor bugs in parsing logic, which result in runtime errors. Before this PR, there were two issues:
- cql-stress converts all CLI arguments to lowercase. Even though c-s is case-insensitive in most of the cases, there are some arguments that cannot be converted to lowercase - them being replication and compaction strategies which. These strings are directly passed to CQL query, which is sent to Scylla. So, let's say that user specifies `replication(strategy=SimpleStrategy)`. `SimpleStrategy` is then being converted to `simplestrategy` and sent in CQL query. This results in runtime DB error (unknown replication strategy/class).
- minor issue with replication/compaction multiparameters and theirs subparameters. The issue is described in detail in the last commit. TLDR - some schema options could be specified twice in some cases, resulting in runtime DB error.

# Changes
- changed the logic so we apply lowercase conversion only in places where original c-s is case-insensitive, such as commands/options, some parameter values (e.g. distribution names)
- fixed issue regarding `replication` and `compaction` multiparameters, where we would specify some schema options twice