### PR TITLE
c-s: counters

### DIFF
--- a/src/bin/cql-stress-cassandra-stress/main.rs
+++ b/src/bin/cql-stress-cassandra-stress/main.rs
@@ -128,7 +128,7 @@ async fn prepare_run(
 
     create_schema(&session, &settings).await?;
 
-    let duration = settings.command_params.basic_params.duration;
+    let duration = settings.command_params.common.duration;
 
     let (concurrency, throttle) = match settings.rate.threads_info {
         ThreadsInfo::Fixed {

--- a/src/bin/cql-stress-cassandra-stress/main.rs
+++ b/src/bin/cql-stress-cassandra-stress/main.rs
@@ -28,6 +28,8 @@ use tracing_subscriber::EnvFilter;
 
 use settings::{CassandraStressParsingResult, CassandraStressSettings};
 
+const DEFAULT_TABLE_NAME: &str = "standard1";
+
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
@@ -189,7 +191,14 @@ async fn create_operation_factory(
             WriteOperationFactory::new(settings, session, workload_factory, stats).await?,
         )),
         Command::Read => Ok(Arc::new(
-            RegularReadOperationFactory::new(settings, session, workload_factory, stats).await?,
+            RegularReadOperationFactory::new(
+                DEFAULT_TABLE_NAME,
+                settings,
+                session,
+                workload_factory,
+                stats,
+            )
+            .await?,
         )),
         Command::CounterWrite => Ok(Arc::new(
             CounterWriteOperationFactory::new(settings, session, workload_factory, stats).await?,

--- a/src/bin/cql-stress-cassandra-stress/main.rs
+++ b/src/bin/cql-stress-cassandra-stress/main.rs
@@ -20,7 +20,7 @@ use cql_stress::{
     sharded_stats::Stats as _,
     sharded_stats::StatsFactory as _,
 };
-use operation::{CounterWriteOperationFactory, WriteOperationFactory};
+use operation::{CounterReadOperationFactory, CounterWriteOperationFactory, WriteOperationFactory};
 use scylla::{transport::session::PoolSize, ExecutionProfile, Session, SessionBuilder};
 use stats::{ShardedStats, StatsFactory, StatsPrinter};
 use std::{env, sync::Arc, time::Duration};
@@ -29,6 +29,7 @@ use tracing_subscriber::EnvFilter;
 use settings::{CassandraStressParsingResult, CassandraStressSettings};
 
 const DEFAULT_TABLE_NAME: &str = "standard1";
+const DEFAULT_COUNTER_TABLE_NAME: &str = "counter1";
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -202,6 +203,16 @@ async fn create_operation_factory(
         )),
         Command::CounterWrite => Ok(Arc::new(
             CounterWriteOperationFactory::new(settings, session, workload_factory, stats).await?,
+        )),
+        Command::CounterRead => Ok(Arc::new(
+            CounterReadOperationFactory::new(
+                DEFAULT_COUNTER_TABLE_NAME,
+                settings,
+                session,
+                workload_factory,
+                stats,
+            )
+            .await?,
         )),
         cmd => Err(anyhow::anyhow!(
             "Runtime for command '{}' not implemented yet.",

--- a/src/bin/cql-stress-cassandra-stress/main.rs
+++ b/src/bin/cql-stress-cassandra-stress/main.rs
@@ -10,7 +10,7 @@ mod stats;
 extern crate lazy_static;
 
 use crate::{
-    operation::{ReadOperationFactory, RowGeneratorFactory},
+    operation::{RegularReadOperationFactory, RowGeneratorFactory},
     settings::{parse_cassandra_stress_args, Command, ThreadsInfo},
 };
 use anyhow::{Context, Result};
@@ -189,7 +189,7 @@ async fn create_operation_factory(
             WriteOperationFactory::new(settings, session, workload_factory, stats).await?,
         )),
         Command::Read => Ok(Arc::new(
-            ReadOperationFactory::new(settings, session, workload_factory, stats).await?,
+            RegularReadOperationFactory::new(settings, session, workload_factory, stats).await?,
         )),
         Command::CounterWrite => Ok(Arc::new(
             CounterWriteOperationFactory::new(settings, session, workload_factory, stats).await?,

--- a/src/bin/cql-stress-cassandra-stress/main.rs
+++ b/src/bin/cql-stress-cassandra-stress/main.rs
@@ -20,7 +20,7 @@ use cql_stress::{
     sharded_stats::Stats as _,
     sharded_stats::StatsFactory as _,
 };
-use operation::WriteOperationFactory;
+use operation::{CounterWriteOperationFactory, WriteOperationFactory};
 use scylla::{transport::session::PoolSize, ExecutionProfile, Session, SessionBuilder};
 use stats::{ShardedStats, StatsFactory, StatsPrinter};
 use std::{env, sync::Arc, time::Duration};
@@ -190,6 +190,9 @@ async fn create_operation_factory(
         )),
         Command::Read => Ok(Arc::new(
             ReadOperationFactory::new(settings, session, workload_factory, stats).await?,
+        )),
+        Command::CounterWrite => Ok(Arc::new(
+            CounterWriteOperationFactory::new(settings, session, workload_factory, stats).await?,
         )),
         cmd => Err(anyhow::anyhow!(
             "Runtime for command '{}' not implemented yet.",

--- a/src/bin/cql-stress-cassandra-stress/operation/counter_write.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/counter_write.rs
@@ -1,0 +1,138 @@
+use anyhow::{Context, Result};
+
+use std::{ops::ControlFlow, sync::Arc};
+
+use cql_stress::{
+    configuration::{Operation, OperationContext, OperationFactory},
+    make_runnable,
+};
+use scylla::frame::response::result::CqlValue;
+use scylla::frame::value::Counter;
+use scylla::{prepared_statement::PreparedStatement, Session};
+
+use crate::{
+    java_generate::distribution::Distribution, settings::CassandraStressSettings,
+    stats::ShardedStats,
+};
+
+use super::{row_generator::RowGenerator, RowGeneratorFactory};
+
+pub struct CounterWriteOperation {
+    session: Arc<Session>,
+    statement: PreparedStatement,
+    workload: RowGenerator,
+    max_operations: Option<u64>,
+    stats: Arc<ShardedStats>,
+    non_pk_columns_count: usize,
+    add_distribution: Box<dyn Distribution>,
+}
+
+pub struct CounterWriteOperationFactory {
+    session: Arc<Session>,
+    statement: PreparedStatement,
+    workload_factory: RowGeneratorFactory,
+    max_operations: Option<u64>,
+    stats: Arc<ShardedStats>,
+    settings: Arc<CassandraStressSettings>,
+}
+
+impl OperationFactory for CounterWriteOperationFactory {
+    fn create(&self) -> Box<dyn Operation> {
+        Box::new(CounterWriteOperation {
+            session: Arc::clone(&self.session),
+            statement: self.statement.clone(),
+            workload: self.workload_factory.create(),
+            max_operations: self.max_operations,
+            stats: Arc::clone(&self.stats),
+            non_pk_columns_count: self.settings.column.columns.len(),
+            add_distribution: self
+                .settings
+                .command_params
+                .counter
+                .as_ref()
+                .unwrap()
+                .add_distribution
+                .create(),
+        })
+    }
+}
+
+impl CounterWriteOperationFactory {
+    fn build_query(settings: &Arc<CassandraStressSettings>) -> String {
+        // Assuming there are non-pk columns [C0, C1, C2], it generates:
+        // "C0"="C0"+?,"C1"="C1"+?,"C2"="C2"+?
+        let columns_str = settings
+            .column
+            .columns
+            .iter()
+            .map(|col| format!("\"{0}\"=\"{0}\"+?", col))
+            .collect::<Vec<_>>()
+            .join(",");
+
+        format!("UPDATE counter1 SET {} WHERE KEY=?", columns_str)
+    }
+
+    pub async fn new(
+        settings: Arc<CassandraStressSettings>,
+        session: Arc<Session>,
+        workload_factory: RowGeneratorFactory,
+        stats: Arc<ShardedStats>,
+    ) -> Result<Self> {
+        // UPDATE counter1 SET "C0"="C0"+?,"C1"="C1"+?,"C2"="C2"+?,"C3"="C3"+?,"C4"="C4"+? WHERE KEY=?
+        let statement_str = Self::build_query(&settings);
+
+        let mut statement = session
+            .prepare(statement_str)
+            .await
+            .context("Failed to prepare statement")?;
+
+        statement.set_consistency(settings.command_params.common.consistency_level);
+        statement.set_serial_consistency(Some(
+            settings.command_params.common.serial_consistency_level,
+        ));
+
+        Ok(Self {
+            session,
+            statement,
+            workload_factory,
+            max_operations: settings.command_params.common.operation_count,
+            stats,
+            settings: Arc::clone(&settings),
+        })
+    }
+}
+
+make_runnable!(CounterWriteOperation);
+impl CounterWriteOperation {
+    async fn execute(&mut self, ctx: &OperationContext) -> Result<ControlFlow<()>> {
+        if self
+            .max_operations
+            .is_some_and(|max_ops| ctx.operation_id >= max_ops)
+        {
+            return Ok(ControlFlow::Break(()));
+        }
+
+        let mut values: Vec<CqlValue> = Vec::with_capacity(self.non_pk_columns_count + 1);
+
+        for _ in 0..self.non_pk_columns_count {
+            values.push(CqlValue::Counter(Counter(self.add_distribution.next_i64())))
+        }
+        let pk = self.workload.generate_pk();
+        values.push(pk);
+
+        let result = self.session.execute(&self.statement, &values).await;
+
+        if let Err(err) = result.as_ref() {
+            tracing::error!(
+                error = %err,
+                partition_key = ?values.last().unwrap(),
+                "counter write error",
+            );
+        }
+
+        self.stats.get_shard_mut().account_operation(ctx, &result);
+        result?;
+
+        Ok(ControlFlow::Continue(()))
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/operation/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/mod.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 use std::num::Wrapping;
 
 pub use counter_write::CounterWriteOperationFactory;
+pub use read::CounterReadOperationFactory;
 pub use read::RegularReadOperationFactory;
 pub use row_generator::RowGeneratorFactory;
 use scylla::{
@@ -86,6 +87,17 @@ impl RowValidator for EqualRowValidator {
             first_row.columns,
             generated_row,
         );
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+pub struct ExistsRowValidator;
+impl RowValidator for ExistsRowValidator {
+    fn validate_row(&self, _generated_row: &[CqlValue], query_result: QueryResult) -> Result<()> {
+        // We only check that the row with given PK exists, which is equivalent to
+        // successfully extracting the first row from the query result.
+        let _first_row = extract_first_row_from_query_result(&query_result)?;
         Ok(())
     }
 }

--- a/src/bin/cql-stress-cassandra-stress/operation/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/mod.rs
@@ -1,3 +1,4 @@
+mod counter_write;
 mod read;
 mod row_generator;
 mod write;
@@ -5,6 +6,7 @@ mod write;
 use anyhow::Result;
 use std::num::Wrapping;
 
+pub use counter_write::CounterWriteOperationFactory;
 pub use read::ReadOperationFactory;
 pub use row_generator::RowGeneratorFactory;
 use scylla::{frame::response::result::CqlValue, QueryResult};

--- a/src/bin/cql-stress-cassandra-stress/operation/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/mod.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use std::num::Wrapping;
 
 pub use counter_write::CounterWriteOperationFactory;
-pub use read::ReadOperationFactory;
+pub use read::RegularReadOperationFactory;
 pub use row_generator::RowGeneratorFactory;
 use scylla::{frame::response::result::CqlValue, QueryResult};
 pub use write::WriteOperationFactory;
@@ -26,51 +26,59 @@ fn recompute_seed(seed: i64, partition_key: &CqlValue) -> i64 {
     }
 }
 
-fn validate_row(generated_row: &[CqlValue], query_result: QueryResult) -> Result<()> {
-    let rows = match query_result.rows {
-        Some(rows) => rows,
-        None => anyhow::bail!("Query result doesn't contain any rows.",),
-    };
+pub trait RowValidator: Sync + Send + Default {
+    fn validate_row(&self, generated_row: &[CqlValue], query_result: QueryResult) -> Result<()>;
+}
 
-    let first_row = match rows.split_first() {
-        Some((first_row, remaining_rows)) => {
-            // Note that row-generation logic behaves in a way that given partition_key,
-            // there is exactly one row with this partition_key.
-            anyhow::ensure!(
-                remaining_rows.is_empty(),
-                "Multiple rows matched the key. Rows: {:?}",
-                rows
-            );
+#[derive(Default)]
+pub struct EqualRowValidator;
+impl RowValidator for EqualRowValidator {
+    fn validate_row(&self, generated_row: &[CqlValue], query_result: QueryResult) -> Result<()> {
+        let rows = match query_result.rows {
+            Some(rows) => rows,
+            None => anyhow::bail!("Query result doesn't contain any rows.",),
+        };
+
+        let first_row = match rows.split_first() {
+            Some((first_row, remaining_rows)) => {
+                // Note that row-generation logic behaves in a way that given partition_key,
+                // there is exactly one row with this partition_key.
+                anyhow::ensure!(
+                    remaining_rows.is_empty(),
+                    "Multiple rows matched the key. Rows: {:?}",
+                    rows
+                );
+                first_row
+            }
+            None => anyhow::bail!("Query result doesn't contain any rows.",),
+        };
+
+        anyhow::ensure!(
+            first_row.columns.len() == generated_row.len(),
+            "Expected row's ({:?}) length: {}. Result row's ({:?}) length: {}",
+            generated_row,
+            generated_row.len(),
+            first_row.columns,
+            first_row.columns.len(),
+        );
+
+        let result =
             first_row
-        }
-        None => anyhow::bail!("Query result doesn't contain any rows.",),
-    };
+                .columns
+                .iter()
+                .zip(generated_row.iter())
+                .all(|(maybe_result, expected)| match maybe_result {
+                    Some(result) => result == expected,
+                    // TODO: For now, we don't permit NULLs.
+                    None => false,
+                });
 
-    anyhow::ensure!(
-        first_row.columns.len() == generated_row.len(),
-        "Expected row's ({:?}) length: {}. Result row's ({:?}) length: {}",
-        generated_row,
-        generated_row.len(),
-        first_row.columns,
-        first_row.columns.len(),
-    );
-
-    let result =
-        first_row
-            .columns
-            .iter()
-            .zip(generated_row.iter())
-            .all(|(maybe_result, expected)| match maybe_result {
-                Some(result) => result == expected,
-                // TODO: For now, we don't permit NULLs.
-                None => false,
-            });
-
-    anyhow::ensure!(
-        result,
-        "The data doesn't match. Result: {:?}. Expected: {:?}.",
-        first_row.columns,
-        generated_row,
-    );
-    Ok(())
+        anyhow::ensure!(
+            result,
+            "The data doesn't match. Result: {:?}. Expected: {:?}.",
+            first_row.columns,
+            generated_row,
+        );
+        Ok(())
+    }
 }

--- a/src/bin/cql-stress-cassandra-stress/operation/read.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/read.rs
@@ -12,7 +12,7 @@ use crate::{settings::CassandraStressSettings, stats::ShardedStats};
 
 use super::{
     row_generator::{RowGenerator, RowGeneratorFactory},
-    EqualRowValidator, RowValidator,
+    EqualRowValidator, ExistsRowValidator, RowValidator,
 };
 
 pub struct ReadOperation<V: RowValidator> {
@@ -34,6 +34,7 @@ pub struct GenericReadOperationFactory<V: RowValidator> {
 }
 
 pub type RegularReadOperationFactory = GenericReadOperationFactory<EqualRowValidator>;
+pub type CounterReadOperationFactory = GenericReadOperationFactory<ExistsRowValidator>;
 
 impl<V: RowValidator + 'static> OperationFactory for GenericReadOperationFactory<V> {
     fn create(&self) -> Box<dyn Operation> {

--- a/src/bin/cql-stress-cassandra-stress/operation/read.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/read.rs
@@ -50,12 +50,13 @@ impl<V: RowValidator + 'static> OperationFactory for GenericReadOperationFactory
 
 impl<V: RowValidator> GenericReadOperationFactory<V> {
     pub async fn new(
+        table_name: &'static str,
         settings: Arc<CassandraStressSettings>,
         session: Arc<Session>,
         workload_factory: RowGeneratorFactory,
         stats: Arc<ShardedStats>,
     ) -> Result<Self> {
-        let statement_str = "SELECT * FROM standard1 WHERE KEY=?";
+        let statement_str = format!("SELECT * FROM {} WHERE KEY=?", table_name);
         let mut statement = session
             .prepare(statement_str)
             .await

--- a/src/bin/cql-stress-cassandra-stress/operation/read.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/read.rs
@@ -57,19 +57,16 @@ impl ReadOperationFactory {
             .context("Failed to prepare statement")?;
 
         statement.set_is_idempotent(true);
-        statement.set_consistency(settings.command_params.basic_params.consistency_level);
+        statement.set_consistency(settings.command_params.common.consistency_level);
         statement.set_serial_consistency(Some(
-            settings
-                .command_params
-                .basic_params
-                .serial_consistency_level,
+            settings.command_params.common.serial_consistency_level,
         ));
 
         Ok(Self {
             session,
             statement,
             workload_factory,
-            max_operations: settings.command_params.basic_params.operation_count,
+            max_operations: settings.command_params.common.operation_count,
             stats,
         })
     }

--- a/src/bin/cql-stress-cassandra-stress/operation/row_generator.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/row_generator.rs
@@ -86,15 +86,19 @@ pub struct RowGeneratorFactory {
 }
 
 impl RowGenerator {
+    pub fn generate_pk(&mut self) -> CqlValue {
+        // Sample the partition_key seed from the shared distribution.
+        let pk_seed = self.pk_seed_distribution.next_i64();
+        self.pk_generator.set_seed(pk_seed);
+        self.pk_generator.generate()
+    }
+
     pub fn generate_row(&mut self) -> Vec<CqlValue> {
         // +1 for partition_key.
         let row_length = self.column_generators.len() + 1;
         let mut result = Vec::with_capacity(row_length);
 
-        // Sample the partition_key seed from the shared distribution.
-        let pk_seed = self.pk_seed_distribution.next_i64();
-        self.pk_generator.set_seed(pk_seed);
-        let key = self.pk_generator.generate();
+        let key = self.generate_pk();
 
         // Compute the seed used for generating the rest of the row.
         let columns_seed = recompute_seed(0, &key);

--- a/src/bin/cql-stress-cassandra-stress/operation/row_generator.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/row_generator.rs
@@ -126,7 +126,9 @@ impl RowGeneratorFactory {
             GeneratorConfig::new(
                 "randomstrkey",
                 None,
-                Some(Box::new(FixedDistribution::new(10))),
+                Some(Box::new(FixedDistribution::new(
+                    self.settings.command_params.common.keysize.get() as i64,
+                ))),
             ),
         );
 

--- a/src/bin/cql-stress-cassandra-stress/operation/write.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/write.rs
@@ -63,19 +63,16 @@ impl WriteOperationFactory {
             .context("Failed to prepare statement")?;
 
         statement.set_is_idempotent(true);
-        statement.set_consistency(settings.command_params.basic_params.consistency_level);
+        statement.set_consistency(settings.command_params.common.consistency_level);
         statement.set_serial_consistency(Some(
-            settings
-                .command_params
-                .basic_params
-                .serial_consistency_level,
+            settings.command_params.common.serial_consistency_level,
         ));
 
         Ok(Self {
             session,
             statement,
             workload_factory,
-            max_operations: settings.command_params.basic_params.operation_count,
+            max_operations: settings.command_params.common.operation_count,
             stats,
         })
     }

--- a/src/bin/cql-stress-cassandra-stress/settings/command/common.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/common.rs
@@ -181,7 +181,7 @@ impl Parsable for SerialConsistencyLevel {
     }
 }
 
-pub struct ReadWriteParams {
+pub struct CommonParams {
     pub uncertainty: Option<Uncertainty>,
     pub no_warmup: bool,
     pub truncate: Truncate,
@@ -191,7 +191,7 @@ pub struct ReadWriteParams {
     pub duration: Option<Duration>,
 }
 
-impl ReadWriteParams {
+impl CommonParams {
     pub fn print_settings(&self, command: &Command) {
         println!("Command:");
         println!("  Type: {}", command.show());
@@ -218,7 +218,7 @@ impl ReadWriteParams {
     }
 }
 
-struct ReadWriteParamHandles {
+struct CommonParamHandles {
     err: SimpleParamHandle<UnitInterval>,
     ngt: SimpleParamHandle<u64>,
     nlt: SimpleParamHandle<u64>,
@@ -230,7 +230,7 @@ struct ReadWriteParamHandles {
     duration: SimpleParamHandle<Duration>,
 }
 
-fn prepare_parser(cmd: &str) -> (ParamsParser, ReadWriteParamHandles) {
+fn prepare_parser(cmd: &str) -> (ParamsParser, CommonParamHandles) {
     let mut parser = ParamsParser::new(cmd);
     let err = parser.simple_param(
         "err<",
@@ -285,7 +285,7 @@ fn prepare_parser(cmd: &str) -> (ParamsParser, ReadWriteParamHandles) {
 
     (
         parser,
-        ReadWriteParamHandles {
+        CommonParamHandles {
             err,
             ngt,
             nlt,
@@ -299,7 +299,7 @@ fn prepare_parser(cmd: &str) -> (ParamsParser, ReadWriteParamHandles) {
     )
 }
 
-fn parse_with_handles(handles: ReadWriteParamHandles) -> ReadWriteParams {
+fn parse_with_handles(handles: CommonParamHandles) -> CommonParams {
     let err = handles.err.get();
     let ngt = handles.ngt.get();
     let nlt = handles.nlt.get();
@@ -316,7 +316,7 @@ fn parse_with_handles(handles: ReadWriteParamHandles) -> ReadWriteParams {
     };
 
     // Parser's regular expressions ensure that String parsing won't fail.
-    ReadWriteParams {
+    CommonParams {
         uncertainty,
         no_warmup,
         truncate,
@@ -327,16 +327,16 @@ fn parse_with_handles(handles: ReadWriteParamHandles) -> ReadWriteParams {
     }
 }
 
-pub fn parse_read_write_params(cmd: &Command, payload: &mut ParsePayload) -> Result<CommandParams> {
+pub fn parse_common_params(cmd: &Command, payload: &mut ParsePayload) -> Result<CommandParams> {
     let args = payload.remove(cmd.show()).unwrap();
     let (parser, handles) = prepare_parser(cmd.show());
     parser.parse(args)?;
     Ok(CommandParams {
-        basic_params: parse_with_handles(handles),
+        common: parse_with_handles(handles),
     })
 }
 
-pub fn print_help_read_write(command_str: &str) {
+pub fn print_help_common(command_str: &str) {
     let (parser, _) = prepare_parser(command_str);
     parser.print_help();
 }
@@ -346,7 +346,7 @@ mod tests {
     use scylla::statement::{Consistency, SerialConsistency};
 
     use crate::settings::command::{
-        read_write::{parse_with_handles, prepare_parser, Truncate},
+        common::{parse_with_handles, prepare_parser, Truncate},
         Command,
     };
 

--- a/src/bin/cql-stress-cassandra-stress/settings/command/common.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/common.rs
@@ -343,7 +343,7 @@ fn prepare_parser(cmd: &str) -> (ParamsParser, CommonParamHandles) {
     (parser, handles)
 }
 
-fn parse_with_handles(handles: CommonParamHandles) -> CommonParams {
+pub fn parse_with_handles(handles: CommonParamHandles) -> CommonParams {
     let err = handles.err.get();
     let ngt = handles.ngt.get();
     let nlt = handles.nlt.get();
@@ -379,6 +379,7 @@ pub fn parse_common_params(cmd: &Command, payload: &mut ParsePayload) -> Result<
     parser.parse(args)?;
     Ok(CommandParams {
         common: parse_with_handles(handles),
+        counter: None,
     })
 }
 

--- a/src/bin/cql-stress-cassandra-stress/settings/command/counter.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/counter.rs
@@ -1,0 +1,64 @@
+use anyhow::Result;
+
+use crate::{
+    java_generate::distribution::DistributionFactory,
+    settings::{
+        param::{ParamsParser, SimpleParamHandle},
+        ParsePayload,
+    },
+};
+
+use super::{common::CommonParamHandles, Command, CommandParams};
+
+pub struct CounterParams {
+    pub add_distribution: Box<dyn DistributionFactory>,
+}
+
+impl CounterParams {
+    pub fn print_settings(&self) {
+        println!("  Counter Increment Distibution: {}", self.add_distribution)
+    }
+
+    pub fn parse(cmd: &Command, payload: &mut ParsePayload) -> Result<CommandParams> {
+        let args = payload.remove(cmd.show()).unwrap();
+        let (parser, common_handles, add_distribution) = prepare_parser(cmd.show());
+        parser.parse(args)?;
+        Ok(CommandParams {
+            common: super::common::parse_with_handles(common_handles),
+            counter: Some(CounterParams {
+                add_distribution: add_distribution.get().unwrap(),
+            }),
+        })
+    }
+}
+
+fn prepare_parser(
+    cmd: &str,
+) -> (
+    ParamsParser,
+    CommonParamHandles,
+    SimpleParamHandle<Box<dyn DistributionFactory>>,
+) {
+    let mut parser = ParamsParser::new(cmd);
+
+    let (mut groups, common_handles) = super::common::add_common_param_groups(&mut parser);
+
+    let add_distribution = parser.distribution_param(
+        "add=",
+        Some("fixed(1)"),
+        "Distribution of value of counter increments",
+        false,
+    );
+
+    for group in groups.iter_mut() {
+        group.push(Box::new(add_distribution.clone()));
+        parser.group(&group.iter().map(|e| e.as_ref()).collect::<Vec<_>>())
+    }
+
+    (parser, common_handles, add_distribution)
+}
+
+pub fn print_help_counter(command_str: &str) {
+    let (parser, _, _) = prepare_parser(command_str);
+    parser.print_help();
+}

--- a/src/bin/cql-stress-cassandra-stress/settings/command/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/mod.rs
@@ -9,15 +9,15 @@ use strum_macros::EnumString;
 
 use anyhow::Result;
 
+mod common;
 mod help;
-mod read_write;
 
-use self::read_write::{parse_read_write_params, print_help_read_write};
+use self::common::{parse_common_params, print_help_common};
 pub use help::print_help;
 
 use super::ParsePayload;
+use common::CommonParams;
 use help::parse_help_command;
-use read_write::ReadWriteParams;
 
 #[derive(Clone, Debug, PartialEq, Eq, EnumIter, AsRefStr, EnumString)]
 #[strum(serialize_all = "snake_case")]
@@ -38,7 +38,7 @@ impl Command {
     fn parse_params(&self, payload: &mut ParsePayload) -> Result<Option<CommandParams>> {
         match self {
             Command::Read | Command::Write | Command::CounterRead | Command::CounterWrite => {
-                Ok(Some(parse_read_write_params(self, payload)?))
+                Ok(Some(parse_common_params(self, payload)?))
             }
             Command::Help => {
                 parse_help_command(payload)?;
@@ -73,7 +73,7 @@ impl Command {
     fn print_help(&self) {
         match self {
             Command::Read | Command::Write | Command::CounterRead | Command::CounterWrite => {
-                print_help_read_write(self.show())
+                print_help_common(self.show())
             }
             Command::Help => help::print_help(),
         }
@@ -82,7 +82,7 @@ impl Command {
 
 pub struct CommandParams {
     // Parameters shared across all of the commands
-    pub basic_params: ReadWriteParams,
+    pub common: CommonParams,
     // TODO:
     // mixed_params: Option<MixedParams>
     // user_params: Option<UserParams>
@@ -90,7 +90,7 @@ pub struct CommandParams {
 
 impl CommandParams {
     pub fn print_settings(&self, cmd: &Command) {
-        self.basic_params.print_settings(cmd);
+        self.common.print_settings(cmd);
     }
 }
 

--- a/src/bin/cql-stress-cassandra-stress/settings/command/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/mod.rs
@@ -10,9 +10,12 @@ use strum_macros::EnumString;
 use anyhow::Result;
 
 mod common;
+mod counter;
 mod help;
 
 use self::common::{parse_common_params, print_help_common};
+use self::counter::print_help_counter;
+use self::counter::CounterParams;
 pub use help::print_help;
 
 use super::ParsePayload;
@@ -37,9 +40,10 @@ impl Command {
 
     fn parse_params(&self, payload: &mut ParsePayload) -> Result<Option<CommandParams>> {
         match self {
-            Command::Read | Command::Write | Command::CounterRead | Command::CounterWrite => {
+            Command::Read | Command::Write | Command::CounterRead => {
                 Ok(Some(parse_common_params(self, payload)?))
             }
+            Command::CounterWrite => Ok(Some(CounterParams::parse(self, payload)?)),
             Command::Help => {
                 parse_help_command(payload)?;
                 Ok(None)
@@ -72,9 +76,8 @@ impl Command {
 
     fn print_help(&self) {
         match self {
-            Command::Read | Command::Write | Command::CounterRead | Command::CounterWrite => {
-                print_help_common(self.show())
-            }
+            Command::Read | Command::Write | Command::CounterRead => print_help_common(self.show()),
+            Command::CounterWrite => print_help_counter(self.show()),
             Command::Help => help::print_help(),
         }
     }
@@ -83,6 +86,7 @@ impl Command {
 pub struct CommandParams {
     // Parameters shared across all of the commands
     pub common: CommonParams,
+    pub counter: Option<CounterParams>,
     // TODO:
     // mixed_params: Option<MixedParams>
     // user_params: Option<UserParams>
@@ -91,6 +95,9 @@ pub struct CommandParams {
 impl CommandParams {
     pub fn print_settings(&self, cmd: &Command) {
         self.common.print_settings(cmd);
+        if let Some(counter) = &self.counter {
+            counter.print_settings()
+        }
     }
 }
 

--- a/src/bin/cql-stress-cassandra-stress/settings/cs_args_bad_test.in
+++ b/src/bin/cql-stress-cassandra-stress/settings/cs_args_bad_test.in
@@ -22,3 +22,7 @@ cassandra-stress write -col size=SEQ(1..10,50)
 cassandra-stress write -col names=foo,bar,baz n=3
 cassandra-stress write -pop dist=foo
 cassandra-stress write -pop dist=SEQ(1..10,50)
+
+# Keysize must be a positive number.
+cassandra-stress write keysize=0
+cassandra-stress write keysize=-1

--- a/src/bin/cql-stress-cassandra-stress/settings/cs_args_bad_test.in
+++ b/src/bin/cql-stress-cassandra-stress/settings/cs_args_bad_test.in
@@ -22,6 +22,7 @@ cassandra-stress write -col size=SEQ(1..10,50)
 cassandra-stress write -col names=foo,bar,baz n=3
 cassandra-stress write -pop dist=foo
 cassandra-stress write -pop dist=SEQ(1..10,50)
+cassandra-stress write add=FIXED(10)
 
 # Keysize must be a positive number.
 cassandra-stress write keysize=0

--- a/src/bin/cql-stress-cassandra-stress/settings/cs_args_good_test.in
+++ b/src/bin/cql-stress-cassandra-stress/settings/cs_args_good_test.in
@@ -21,9 +21,9 @@ cassandra-stress counter_write no-warmup cl=QUORUM duration=20m -schema replicat
 cassandra-stress counter_write no-warmup cl=QUORUM duration=20m -schema replication(strategy=NetworkTopologyStrategy)
 cassandra-stress counter_write no-warmup cl=QUORUM duration=20m -schema replication(replication_factor=3)
 cassandra-stress counter_write no-warmup cl=LOCAL_ONE duration=20m -schema replication(strategy=NetworkTopologyStrategy,replication_factor=3) keyspace=keyspace2
-cassandra-stress counter_write no-warmup cl=THREE duration=20m -schema keyspace=keyspace2
-cassandra-stress counter_write no-warmup cl=ANY duration=20m -schema replication(strategy=NetworkTopologyStrategy) keyspace=keyspace2
-cassandra-stress counter_write no-warmup cl=ALL duration=20m -schema replication(replication_factor=3) keyspace=keyspace2
+cassandra-stress counter_write no-warmup add=UNIFORM(1..10) cl=THREE duration=20m -schema keyspace=keyspace2
+cassandra-stress counter_write no-warmup add=GAUSSIAN(1..10) cl=ANY duration=20m -schema replication(strategy=NetworkTopologyStrategy) keyspace=keyspace2
+cassandra-stress counter_write no-warmup add=FIXED(2) cl=ALL duration=20m -schema replication(replication_factor=3) keyspace=keyspace2
 cassandra-stress counter_write no-warmup cl=ALL duration=20m -schema replication(replication_factor=3) keyspace=keyspace2 -node shard-connection-count=5
 cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1) -rate threads=10 -col n=10 size=UNIFORM(1..20)
 cassandra-stress read cl=QUORUM n=10000 -schema replication(key=value) -rate threads=10 -col names=foo,bar,baz

--- a/src/bin/cql-stress-cassandra-stress/settings/cs_args_good_test.in
+++ b/src/bin/cql-stress-cassandra-stress/settings/cs_args_good_test.in
@@ -3,6 +3,8 @@ cassandra-stress write no-warmup cl=quorum n=10b truncate=always
 cassandra-stress counter_read cl=QUORUM duration=5760m
 cassandra-stress write no-warmup cl=QUORUM duration=30m
 cassandra-stress write no-warmup serial-cl=LOCAL_SERIAL
+cassandra-stress write cl=ONE n=10000 keysize=5
+cassandra-stress write err<0.2 n>20 keysize=15
 cassandra-stress write err<0.2 n>20
 cassandra-stress write
 cassandra-stress read

--- a/src/bin/cql-stress-cassandra-stress/settings/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/mod.rs
@@ -166,7 +166,7 @@ where
         // The default distribution (if not specified) is SEQ(1..operation_count).
         // If operation_count is not specified, then the default is 1M.
         let operation_count = command_params
-            .basic_params
+            .common
             .operation_count
             .map_or(String::from("1000000"), |op| format!("{op}"));
         let population = PopulationOption::parse(&mut payload, &operation_count)?;

--- a/src/bin/cql-stress-cassandra-stress/settings/param/multi_param.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/multi_param.rs
@@ -229,6 +229,14 @@ pub struct MultiParamHandle<A: ArbitraryParamsAcceptance> {
     cell: Rc<RefCell<TypedParam<MultiParam<A>>>>,
 }
 
+impl<A: ArbitraryParamsAcceptance> Clone for MultiParamHandle<A> {
+    fn clone(&self) -> Self {
+        Self {
+            cell: Rc::clone(&self.cell),
+        }
+    }
+}
+
 pub type MultiParamAcceptsArbitraryHandle = MultiParamHandle<AcceptsArbitraryParams>;
 
 impl MultiParamAcceptsArbitraryHandle {

--- a/src/bin/cql-stress-cassandra-stress/settings/param/simple_param.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/simple_param.rs
@@ -85,6 +85,14 @@ pub struct SimpleParamHandle<T: Parsable> {
     cell: Rc<RefCell<TypedParam<SimpleParam<T>>>>,
 }
 
+impl<T: Parsable> Clone for SimpleParamHandle<T> {
+    fn clone(&self) -> Self {
+        Self {
+            cell: Rc::clone(&self.cell),
+        }
+    }
+}
+
 impl<T: Parsable> SimpleParamHandle<T> {
     pub fn new(cell: Rc<RefCell<TypedParam<SimpleParam<T>>>>) -> Self {
         Self { cell }

--- a/src/bin/cql-stress-cassandra-stress/settings/param/types.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/types.rs
@@ -1,4 +1,7 @@
-use std::{num::NonZeroUsize, time::Duration};
+use std::{
+    num::{NonZeroU32, NonZeroUsize},
+    time::Duration,
+};
 
 use anyhow::{Context, Result};
 use cql_stress::distribution::{parse_description, SyntaxFlavor};
@@ -53,6 +56,15 @@ impl Parsable for NonZeroUsize {
     fn parse(s: &str) -> Result<Self::Parsed> {
         s.parse::<NonZeroUsize>()
             .with_context(|| format!("Invalid non-zero usize value: {s}"))
+    }
+}
+
+impl Parsable for NonZeroU32 {
+    type Parsed = NonZeroU32;
+
+    fn parse(s: &str) -> Result<Self::Parsed> {
+        s.parse::<NonZeroU32>()
+            .with_context(|| format!("Invalid non-zero u32 value: {s}"))
     }
 }
 

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -111,9 +111,9 @@ pub trait Operation: Send + Sync {
 /// can be clearly visible on the flamegraphs.
 #[macro_export]
 macro_rules! make_runnable {
-    ($op:ty) => {
+    ($op:ident$(<$($targ:tt: $tbound:tt),+>)?) => {
         #[async_trait]
-        impl $crate::configuration::Operation for $op {
+        impl$(<$($targ: $tbound),+>)? $crate::configuration::Operation for $op$(<$($targ),*>)? {
             async fn run(&mut self, mut session: $crate::run::WorkerSession) -> anyhow::Result<()> {
                 while let Some(ctx) = session.start_operation().await {
                     let result = self.execute(&ctx).await;


### PR DESCRIPTION
# Changes
Implemented runtime for both `counter_read` and `counter_write` commands.

This includes:
- renaming `ReadWriteParams` to `CommonParams`
- parsing additional parameter for `counter_write` command (`add=`)
- making `ReadOperation` generic over `RowValidator` trait, since `counter_read` differs from `read` only with validation logic
- implemented `CounterWriteOperation`
- implemented `CounterReadOperation` (as `ReadOperation<ExistsRowValidator>`)