### PR TITLE
c-s options: fix compiler warnings

### DIFF
--- a/src/bin/cql-stress-cassandra-stress/settings/option/column.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/option/column.rs
@@ -14,7 +14,7 @@ pub struct ColumnOption {
 }
 
 impl ColumnOption {
-    pub const CLI_STRING: &str = "-col";
+    pub const CLI_STRING: &'static str = "-col";
 
     pub fn description() -> &'static str {
         "Column details such as size distribution, names"

--- a/src/bin/cql-stress-cassandra-stress/settings/option/node.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/option/node.rs
@@ -24,7 +24,7 @@ pub struct NodeOption {
 }
 
 impl NodeOption {
-    pub const CLI_STRING: &str = "-node";
+    pub const CLI_STRING: &'static str = "-node";
 
     pub fn description() -> &'static str {
         "Nodes to connect to"

--- a/src/bin/cql-stress-cassandra-stress/settings/option/population.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/option/population.rs
@@ -13,7 +13,7 @@ pub struct PopulationOption {
 }
 
 impl PopulationOption {
-    pub const CLI_STRING: &str = "-pop";
+    pub const CLI_STRING: &'static str = "-pop";
 
     pub fn description() -> &'static str {
         "Population distribution"

--- a/src/bin/cql-stress-cassandra-stress/settings/option/rate.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/option/rate.rs
@@ -50,7 +50,7 @@ impl ThreadsInfo {
 }
 
 impl RateOption {
-    pub const CLI_STRING: &str = "-rate";
+    pub const CLI_STRING: &'static str = "-rate";
 
     pub fn description() -> &'static str {
         "Thread count, rate limit or automatic mode (default is auto)"

--- a/src/bin/cql-stress-cassandra-stress/settings/option/schema.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/option/schema.rs
@@ -17,7 +17,7 @@ impl SchemaOption {
         "Replication settings, compression, compaction, etc."
     }
 
-    pub const CLI_STRING: &str = "-schema";
+    pub const CLI_STRING: &'static str = "-schema";
 
     pub fn parse(cl_args: &mut ParsePayload) -> Result<Self> {
         let params = cl_args.remove(Self::CLI_STRING).unwrap_or_default();


### PR DESCRIPTION
New rust version expects us to explicitly specify the lifetime of const string variables. Right now, it only generates warnings which result in clippy errors during CI.

See:
```
= warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
= note: for more information, see issue #115010 <https://github.com/rust-lang/rust/issues/115010>
```