### PR TITLE
c-s mixed operation

### DIFF
--- a/src/bin/cql-stress-cassandra-stress/java_generate/distribution/enumerated.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/distribution/enumerated.rs
@@ -1,0 +1,33 @@
+use anyhow::Result;
+use rand_distr::{Distribution, WeightedIndex};
+
+#[derive(Clone)]
+pub struct EnumeratedDistribution<T> {
+    items: Vec<(T, f64)>,
+    dist: WeightedIndex<f64>,
+}
+
+impl<T: Copy> EnumeratedDistribution<T> {
+    pub fn new(items: Vec<(T, f64)>) -> Result<Self> {
+        let dist = WeightedIndex::new(items.iter().map(|w| w.1))?;
+
+        Ok(Self { items, dist })
+    }
+
+    pub fn sample(&self) -> T {
+        self.items[self.dist.sample(&mut rand::thread_rng())].0
+    }
+}
+
+impl<T: std::fmt::Display> std::fmt::Display for EnumeratedDistribution<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{")?;
+        let items_str = self
+            .items
+            .iter()
+            .map(|item| format!("{}={}", item.0, item.1))
+            .collect::<Vec<_>>()
+            .join(",");
+        write!(f, "{}}}", items_str)
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/java_generate/distribution/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/distribution/mod.rs
@@ -7,6 +7,7 @@ use thread_local::ThreadLocal;
 
 use super::Random;
 
+pub mod enumerated;
 pub mod fixed;
 pub mod normal;
 pub mod sequence;

--- a/src/bin/cql-stress-cassandra-stress/main.rs
+++ b/src/bin/cql-stress-cassandra-stress/main.rs
@@ -20,7 +20,10 @@ use cql_stress::{
     sharded_stats::Stats as _,
     sharded_stats::StatsFactory as _,
 };
-use operation::{CounterReadOperationFactory, CounterWriteOperationFactory, WriteOperationFactory};
+use operation::{
+    CounterReadOperationFactory, CounterWriteOperationFactory, MixedOperationFactory,
+    WriteOperationFactory,
+};
 use scylla::{transport::session::PoolSize, ExecutionProfile, Session, SessionBuilder};
 use stats::{ShardedStats, StatsFactory, StatsPrinter};
 use std::{env, sync::Arc, time::Duration};
@@ -198,6 +201,9 @@ async fn create_operation_factory(
         )),
         Command::CounterRead => Ok(Arc::new(
             CounterReadOperationFactory::new(settings, session, workload_factory, stats).await?,
+        )),
+        Command::Mixed => Ok(Arc::new(
+            MixedOperationFactory::new(settings, session, workload_factory, stats).await?,
         )),
         cmd => Err(anyhow::anyhow!(
             "Runtime for command '{}' not implemented yet.",

--- a/src/bin/cql-stress-cassandra-stress/operation/mixed.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/mixed.rs
@@ -1,0 +1,169 @@
+use anyhow::Result;
+use std::{ops::ControlFlow, sync::Arc};
+
+use cql_stress::{
+    configuration::{Operation, OperationContext, OperationFactory},
+    make_runnable,
+};
+use scylla::{frame::response::result::CqlValue, Session};
+
+use crate::{
+    java_generate::distribution::Distribution,
+    settings::{CassandraStressSettings, MixedSubcommand, OperationRatio},
+    stats::ShardedStats,
+};
+
+use super::{
+    counter_write::{CounterWriteOperation, CounterWriteOperationFactory},
+    read::{
+        CounterReadOperation, CounterReadOperationFactory, RegularReadOperation,
+        RegularReadOperationFactory,
+    },
+    row_generator::RowGenerator,
+    write::{WriteOperation, WriteOperationFactory},
+    CassandraStressOperation, CassandraStressOperationFactory, RowGeneratorFactory,
+    DEFAULT_COUNTER_TABLE_NAME, DEFAULT_TABLE_NAME,
+};
+
+pub struct MixedOperation {
+    write_operation: WriteOperation,
+    counter_write_operation: CounterWriteOperation,
+    read_operation: RegularReadOperation,
+    counter_read_operation: CounterReadOperation,
+    cached_row: Option<Vec<CqlValue>>,
+    workload: RowGenerator,
+    max_operations: Option<u64>,
+    stats: Arc<ShardedStats>,
+    operation_ratio: Arc<OperationRatio>,
+    clustering_distribution: Box<dyn Distribution>,
+    current_operation: MixedSubcommand,
+    current_operation_remaining: usize,
+}
+
+pub struct MixedOperationFactory {
+    settings: Arc<CassandraStressSettings>,
+    write_operation_factory: WriteOperationFactory,
+    counter_write_operation_factory: CounterWriteOperationFactory,
+    read_operation_factory: RegularReadOperationFactory,
+    counter_read_operation_factory: CounterReadOperationFactory,
+    operation_ratio: Arc<OperationRatio>,
+    workload_factory: RowGeneratorFactory,
+    max_operations: Option<u64>,
+    stats: Arc<ShardedStats>,
+}
+
+impl OperationFactory for MixedOperationFactory {
+    fn create(&self) -> Box<dyn Operation> {
+        let mixed_params = self.settings.command_params.mixed.as_ref().unwrap();
+
+        let write_operation = self.write_operation_factory.create();
+        let counter_write_operation = self.counter_write_operation_factory.create();
+        let read_operation = self.read_operation_factory.create();
+        let counter_read_operation = self.counter_read_operation_factory.create();
+
+        Box::new(MixedOperation {
+            write_operation,
+            counter_write_operation,
+            read_operation,
+            counter_read_operation,
+            cached_row: None,
+            workload: self.workload_factory.create(),
+            max_operations: self.max_operations,
+            stats: Arc::clone(&self.stats),
+            operation_ratio: Arc::clone(&self.operation_ratio),
+            clustering_distribution: mixed_params.clustering.create(),
+            current_operation: MixedSubcommand::Read,
+            current_operation_remaining: 0,
+        })
+    }
+}
+
+impl MixedOperationFactory {
+    pub async fn new(
+        settings: Arc<CassandraStressSettings>,
+        session: Arc<Session>,
+        workload_factory: RowGeneratorFactory,
+        stats: Arc<ShardedStats>,
+    ) -> Result<Self> {
+        let mixed_params = settings.command_params.mixed.as_ref().unwrap();
+        let max_operations = settings.command_params.common.operation_count;
+        let operation_ratio = Arc::new(mixed_params.operation_ratio.clone());
+        let write_operation_factory =
+            WriteOperationFactory::new(settings.clone(), session.clone()).await?;
+        let counter_write_operation_factory =
+            CounterWriteOperationFactory::new(settings.clone(), session.clone()).await?;
+        let read_operation_factory =
+            RegularReadOperationFactory::new(settings.clone(), session.clone(), DEFAULT_TABLE_NAME)
+                .await?;
+        let counter_read_operation_factory =
+            CounterReadOperationFactory::new(settings.clone(), session, DEFAULT_COUNTER_TABLE_NAME)
+                .await?;
+
+        Ok(Self {
+            settings,
+            write_operation_factory,
+            counter_write_operation_factory,
+            read_operation_factory,
+            counter_read_operation_factory,
+            operation_ratio,
+            workload_factory,
+            max_operations,
+            stats,
+        })
+    }
+}
+
+make_runnable!(MixedOperation);
+impl MixedOperation {
+    async fn execute(&mut self, ctx: &OperationContext) -> Result<ControlFlow<()>> {
+        if self
+            .max_operations
+            .is_some_and(|max_ops| ctx.operation_id >= max_ops)
+        {
+            return Ok(ControlFlow::Break(()));
+        }
+
+        if self.current_operation_remaining == 0 {
+            self.current_operation = self.operation_ratio.sample();
+            self.current_operation_remaining =
+                (self.clustering_distribution.next_i64() as usize).max(1);
+        }
+
+        let result = match &self.current_operation {
+            MixedSubcommand::Read => {
+                let row = self
+                    .cached_row
+                    .get_or_insert_with(|| self.read_operation.generate_row(&mut self.workload));
+                self.read_operation.execute(row).await
+            }
+            MixedSubcommand::CounterRead => {
+                let row = self.cached_row.get_or_insert_with(|| {
+                    self.counter_read_operation.generate_row(&mut self.workload)
+                });
+                self.counter_read_operation.execute(row).await
+            }
+            MixedSubcommand::Write => {
+                let row = self
+                    .cached_row
+                    .get_or_insert_with(|| self.write_operation.generate_row(&mut self.workload));
+                self.write_operation.execute(row).await
+            }
+            MixedSubcommand::CounterWrite => {
+                let row = self.cached_row.get_or_insert_with(|| {
+                    self.counter_write_operation
+                        .generate_row(&mut self.workload)
+                });
+                self.counter_write_operation.execute(row).await
+            }
+        };
+
+        self.stats.get_shard_mut().account_operation(ctx, &result);
+
+        if result.is_ok() {
+            self.current_operation_remaining -= 1;
+            self.cached_row = None;
+        }
+
+        result
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/operation/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/mod.rs
@@ -1,4 +1,5 @@
 mod counter_write;
+mod mixed;
 mod read;
 mod row_generator;
 mod write;
@@ -14,6 +15,7 @@ use std::num::Wrapping;
 use std::ops::ControlFlow;
 use std::sync::Arc;
 
+pub use mixed::MixedOperationFactory;
 pub use row_generator::RowGeneratorFactory;
 use scylla::{
     frame::response::result::{CqlValue, Row},

--- a/src/bin/cql-stress-cassandra-stress/settings/command/common.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/common.rs
@@ -380,6 +380,7 @@ pub fn parse_common_params(cmd: &Command, payload: &mut ParsePayload) -> Result<
     Ok(CommandParams {
         common: parse_with_handles(handles),
         counter: None,
+        mixed: None,
     })
 }
 

--- a/src/bin/cql-stress-cassandra-stress/settings/command/counter.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/counter.rs
@@ -28,6 +28,7 @@ impl CounterParams {
             counter: Some(CounterParams {
                 add_distribution: add_distribution.get().unwrap(),
             }),
+            mixed: None,
         })
     }
 }

--- a/src/bin/cql-stress-cassandra-stress/settings/command/counter.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/counter.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use crate::{
     java_generate::distribution::DistributionFactory,
     settings::{
-        param::{ParamsParser, SimpleParamHandle},
+        param::{ParamHandle, ParamsParser, SimpleParamHandle},
         ParsePayload,
     },
 };
@@ -32,6 +32,33 @@ impl CounterParams {
     }
 }
 
+pub struct CounterParamGroups {
+    pub groups: Vec<Vec<Box<dyn ParamHandle>>>,
+    pub common_handles: CommonParamHandles,
+    pub add_distribution_handle: SimpleParamHandle<Box<dyn DistributionFactory>>,
+}
+
+pub fn add_counter_param_groups(parser: &mut ParamsParser) -> CounterParamGroups {
+    let (mut groups, common_handles) = super::common::add_common_param_groups(parser);
+
+    let add_distribution_handle = parser.distribution_param(
+        "add=",
+        Some("fixed(1)"),
+        "Distribution of value of counter increments",
+        false,
+    );
+
+    for group in groups.iter_mut() {
+        group.push(Box::new(add_distribution_handle.clone()));
+    }
+
+    CounterParamGroups {
+        groups,
+        common_handles,
+        add_distribution_handle,
+    }
+}
+
 fn prepare_parser(
     cmd: &str,
 ) -> (
@@ -41,21 +68,17 @@ fn prepare_parser(
 ) {
     let mut parser = ParamsParser::new(cmd);
 
-    let (mut groups, common_handles) = super::common::add_common_param_groups(&mut parser);
+    let mut counter_payload = add_counter_param_groups(&mut parser);
 
-    let add_distribution = parser.distribution_param(
-        "add=",
-        Some("fixed(1)"),
-        "Distribution of value of counter increments",
-        false,
-    );
-
-    for group in groups.iter_mut() {
-        group.push(Box::new(add_distribution.clone()));
+    for group in counter_payload.groups.iter_mut() {
         parser.group(&group.iter().map(|e| e.as_ref()).collect::<Vec<_>>())
     }
 
-    (parser, common_handles, add_distribution)
+    (
+        parser,
+        counter_payload.common_handles,
+        counter_payload.add_distribution_handle,
+    )
 }
 
 pub fn print_help_counter(command_str: &str) {

--- a/src/bin/cql-stress-cassandra-stress/settings/command/mixed.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/mixed.rs
@@ -1,0 +1,106 @@
+use std::collections::HashSet;
+
+use crate::{
+    java_generate::distribution::enumerated::EnumeratedDistribution,
+    settings::param::types::Parsable,
+};
+use anyhow::{Context, Result};
+
+use super::Command;
+
+// Available subcommands for mixed command.
+#[derive(Copy, Clone, Hash, PartialEq, Eq)]
+pub enum MixedSubcommand {
+    Read,
+    Write,
+    CounterRead,
+    CounterWrite,
+}
+
+impl std::fmt::Display for MixedSubcommand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            MixedSubcommand::Read => "read",
+            MixedSubcommand::Write => "write",
+            MixedSubcommand::CounterRead => "counter_read",
+            MixedSubcommand::CounterWrite => "counter_write",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+pub type OperationRatio = EnumeratedDistribution<MixedSubcommand>;
+
+// There are 4 suboperations which can be sampled during mixed workloads:
+// - read
+// - write
+// - counter_read
+// - counter_write
+//
+// A user can specify a ratio with which the suboperations will be sampled.
+// The syntax for this parameter is (op1=x, op2=y, op3=z, ...)
+// where op1..n are one of the 4 operations mentioned above, and x,y,z are floats.
+//
+// For example:
+// ratio(read=1, write=2) means that there will be approximately 1 read operation per 2 write operations.
+impl Parsable for OperationRatio {
+    type Parsed = Self;
+
+    fn parse(s: &str) -> Result<Self::Parsed> {
+        Self::do_parse(s).with_context(|| format!("invalid operation ratio specification: {}", s))
+    }
+}
+
+impl OperationRatio {
+    fn parse_command_weight(s: &str) -> Result<(MixedSubcommand, f64)> {
+        let (cmd, weight) = {
+            let mut iter = s.split('=').fuse();
+            match (iter.next(), iter.next(), iter.next()) {
+                (Some(cmd), Some(w), None) => (cmd, w),
+                _ => anyhow::bail!(
+                    "Command weight specification should match pattern <command>=<f64>"
+                ),
+            }
+        };
+
+        let command = match Command::parse(cmd)? {
+            Command::Read => MixedSubcommand::Read,
+            Command::Write => MixedSubcommand::Write,
+            Command::CounterRead => MixedSubcommand::CounterRead,
+            Command::CounterWrite => MixedSubcommand::CounterWrite,
+            _ => anyhow::bail!("Invalid command for mixed workload: {}", cmd),
+        };
+        let weight = weight.parse::<f64>()?;
+        Ok((command, weight))
+    }
+
+    fn do_parse(s: &str) -> Result<Self> {
+        // Remove wrapping parenthesis.
+        let arg = {
+            let mut chars = s.chars();
+            anyhow::ensure!(
+                chars.next() == Some('(') && chars.next_back() == Some(')'),
+                "Invalid operation ratio specification: {}",
+                s
+            );
+            chars.as_str()
+        };
+
+        let mut command_set = HashSet::<MixedSubcommand>::new();
+        let weights = arg
+            .split(',')
+            .map(|s| -> Result<(MixedSubcommand, f64)> {
+                let (command, weight) = Self::parse_command_weight(s)?;
+                anyhow::ensure!(
+                    !command_set.contains(&command),
+                    "{} command has been specified more than once",
+                    command
+                );
+                command_set.insert(command);
+                Ok((command, weight))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Self::new(weights)
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/settings/command/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/mod.rs
@@ -17,7 +17,8 @@ mod mixed;
 use self::common::{parse_common_params, print_help_common};
 use self::counter::print_help_counter;
 use self::counter::CounterParams;
-
+use self::mixed::print_help_mixed;
+use self::mixed::MixedParams;
 pub use help::print_help;
 
 use super::ParsePayload;
@@ -35,6 +36,7 @@ pub enum Command {
     Read,
     CounterWrite,
     CounterRead,
+    Mixed,
 }
 
 impl Command {
@@ -48,6 +50,7 @@ impl Command {
                 Ok(Some(parse_common_params(self, payload)?))
             }
             Command::CounterWrite => Ok(Some(CounterParams::parse(self, payload)?)),
+            Command::Mixed => Ok(Some(MixedParams::parse(self, payload)?)),
             Command::Help => {
                 parse_help_command(payload)?;
                 Ok(None)
@@ -65,6 +68,7 @@ impl Command {
             Command::Write => "Multiple concurrent writes against the cluster.",
             Command::CounterWrite => "Multiple concurrent updates of counters.",
             Command::CounterRead => "Multiple concurrent reads of counters. The cluster must first be populated by a counterwrite test.",
+            Command::Mixed => "Interleaving of any basic commands, with configurable ratio and distribution - the cluster must first be populated by a write test.",
             Command::Help => "Print help for a command or option",
         };
 
@@ -82,6 +86,7 @@ impl Command {
         match self {
             Command::Read | Command::Write | Command::CounterRead => print_help_common(self.show()),
             Command::CounterWrite => print_help_counter(self.show()),
+            Command::Mixed => print_help_mixed(self.show()),
             Command::Help => help::print_help(),
         }
     }
@@ -91,6 +96,7 @@ pub struct CommandParams {
     // Parameters shared across all of the commands
     pub common: CommonParams,
     pub counter: Option<CounterParams>,
+    pub mixed: Option<MixedParams>,
 }
 
 impl CommandParams {
@@ -98,6 +104,9 @@ impl CommandParams {
         self.common.print_settings(cmd);
         if let Some(counter) = &self.counter {
             counter.print_settings()
+        }
+        if let Some(mixed) = &self.mixed {
+            mixed.print_settings()
         }
     }
 }

--- a/src/bin/cql-stress-cassandra-stress/settings/command/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/mod.rs
@@ -12,15 +12,19 @@ use anyhow::Result;
 mod common;
 mod counter;
 mod help;
+mod mixed;
 
 use self::common::{parse_common_params, print_help_common};
 use self::counter::print_help_counter;
 use self::counter::CounterParams;
+
 pub use help::print_help;
 
 use super::ParsePayload;
 use common::CommonParams;
 use help::parse_help_command;
+pub use mixed::MixedSubcommand;
+pub use mixed::OperationRatio;
 
 #[derive(Clone, Debug, PartialEq, Eq, EnumIter, AsRefStr, EnumString)]
 #[strum(serialize_all = "snake_case")]
@@ -87,9 +91,6 @@ pub struct CommandParams {
     // Parameters shared across all of the commands
     pub common: CommonParams,
     pub counter: Option<CounterParams>,
-    // TODO:
-    // mixed_params: Option<MixedParams>
-    // user_params: Option<UserParams>
 }
 
 impl CommandParams {

--- a/src/bin/cql-stress-cassandra-stress/settings/cs_args_bad_test.in
+++ b/src/bin/cql-stress-cassandra-stress/settings/cs_args_bad_test.in
@@ -30,3 +30,9 @@ cassandra-stress write add=FIXED(10)
 # Keysize must be a positive number.
 cassandra-stress write keysize=0
 cassandra-stress write keysize=-1
+
+cassandra-stress mixed ratio(help=1)
+cassandra-stress mixed ratio(mixed=1)
+cassandra-stress mixed ratio()
+cassandra-stress read ratio(read=1,write=2)
+cassandra-stress read clustering=FIXED(2)

--- a/src/bin/cql-stress-cassandra-stress/settings/cs_args_good_test.in
+++ b/src/bin/cql-stress-cassandra-stress/settings/cs_args_good_test.in
@@ -35,3 +35,6 @@ cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1, key=value)
 
 # This tests the case sensitivity of throttle= parameter's value. We should accept both /S and /s.
 cassandra-stress read no-warmup cl=QUORUM duration=600M -rate threads=80 throttle=8000/S
+
+cassandra-stress mixed ratio(read=1,write=1) clustering=FIXED(10)
+cassandra-stress mixed ratio(read=1)

--- a/src/bin/cql-stress-cassandra-stress/settings/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/mod.rs
@@ -11,6 +11,8 @@ mod test;
 
 pub use command::Command;
 pub use command::CommandParams;
+pub use command::MixedSubcommand;
+pub use command::OperationRatio;
 pub use option::ThreadsInfo;
 use regex::Regex;
 


### PR DESCRIPTION
# Motivation
Cassandra-stress supports mixed workloads. It allows to run multiple kinds of operations. Allowed operations are:
- read
- write
- counter_read
- counter_write

The parameters supported by `mixed` command are:
- all of the common parameters (e.g. used by `read`)
- all of the `counter_write` parameters
- `ratio()` parameter based on which tool samples an operation to execute. E.g. `ratio(read=2, write=1)` means that there will be approximately 2 read operations per 1 write operation.
- `clustering` distribution parameter which tells the tool how many times to run the operation that just got sampled.

# Changes
- Prepared `settings` module for `MixedOperation`
- Implemented `MixedOperation`