### PR TITLE
main: set max_retries_per_op to 9 (c-s default)

### DIFF
--- a/src/bin/cql-stress-cassandra-stress/main.rs
+++ b/src/bin/cql-stress-cassandra-stress/main.rs
@@ -149,7 +149,8 @@ async fn prepare_run(
         concurrency,
         rate_limit_per_second: throttle,
         operation_factory,
-        max_retries_per_op: 0,
+        // TODO: adjust when -errors option is supported
+        max_retries_per_op: 9,
     })
 }
 


### PR DESCRIPTION
# Motivation

By default, cassandra-stress takes 9 attempts to perform an operation before ending the benchmark with failure.

Before this PR, cql-stress would fail immediately after first failed operation. This resulted in SCT run failures (SCT + cql-stress) when some nemesis would kill one of the nodes in the cluster:
```
   7689156,   32227,     0.9,     0.8,     1.6,     2.1,     4.7,     9.0,  256.0,      0
   7720832,   31675,     0.9,     0.9,     1.6,     2.1,     3.6,     7.3,  257.0,      0
   7753593,   32738,     0.9,     0.8,     1.5,     2.0,     3.9,     7.3,  258.0,      0
[2m2023-12-15T15:22:44.866516Z[0m [31mERROR[0m [2mcql_stress_cassandra_stress::operation::read[0m[2m:[0m read error [3merror[0m[2m=[0mInvalid message: Frame error: early eof [3mpartition_key[0m[2m=[0mBlob([80, 48, 51, 53, 55, 54, 75, 75, 49, 49])
[2m2023-12-15T15:22:44.866544Z[0m [31mERROR[0m [2mcql_stress_cassandra_stress::operation::read[0m[2m:[0m read error [3merror[0m[2m=[0mInvalid message: Frame error: early eof [3mpartition_key[0m[2m=[0mBlob([78, 57, 55, 55, 76, 56, 48, 75, 54, 48])
Error: An error occurred during the benchmark

Caused by:
    Invalid message: Frame error: early eof
``` 

When changing the `max_retries_per_op` to c-s default, the SCT run finishes successfully.

# Changes
- hardcoded config's `max_retries_per_op` parameter to 9 (cassandra-stress default). Note that this will be adjusted in the future when `-errors` CLI option is supported.