### PR TITLE
tracing: disable ansi colors

### DIFF
--- a/src/bin/cql-stress-cassandra-stress/main.rs
+++ b/src/bin/cql-stress-cassandra-stress/main.rs
@@ -34,6 +34,7 @@ const DEFAULT_COUNTER_TABLE_NAME: &str = "counter1";
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
+        .with_ansi(false)
         .with_env_filter(EnvFilter::try_from_default_env().unwrap_or(EnvFilter::new("warn")))
         .init();
 

--- a/src/bin/cql-stress-scylla-bench/main.rs
+++ b/src/bin/cql-stress-scylla-bench/main.rs
@@ -42,6 +42,7 @@ use crate::workload::{
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
+        .with_ansi(false)
         .with_env_filter(EnvFilter::try_from_default_env().unwrap_or(EnvFilter::new("warn")))
         .init();
 


### PR DESCRIPTION
SCT logs are hard to read because of the ansi colors emitted by the `tracing-subscriber` crate by default:
```
�[2m2024-01-05T13:09:31.237763Z�[0m �[31mERROR�[0m �[2mcql_stress_cassandra_stress::operation::write�[0m�[2m:�[0m write error �[3merror�[0m�[2m=�[0mInvalid message: Frame error: early eof �[3mpartition_key�[0m�[2m=�[0mBlob([76, 79, 55, 77, 53, 57, 56, 76, 77, 48])
```

This PR disables ansi colors in the `tracing` logs.