### PR TITLE
c-s operation: Extract common operation logic

### DIFF
--- a/src/bin/cql-stress-cassandra-stress/main.rs
+++ b/src/bin/cql-stress-cassandra-stress/main.rs
@@ -28,9 +28,6 @@ use tracing_subscriber::EnvFilter;
 
 use settings::{CassandraStressParsingResult, CassandraStressSettings};
 
-const DEFAULT_TABLE_NAME: &str = "standard1";
-const DEFAULT_COUNTER_TABLE_NAME: &str = "counter1";
-
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
@@ -194,27 +191,13 @@ async fn create_operation_factory(
             WriteOperationFactory::new(settings, session, workload_factory, stats).await?,
         )),
         Command::Read => Ok(Arc::new(
-            RegularReadOperationFactory::new(
-                DEFAULT_TABLE_NAME,
-                settings,
-                session,
-                workload_factory,
-                stats,
-            )
-            .await?,
+            RegularReadOperationFactory::new(settings, session, workload_factory, stats).await?,
         )),
         Command::CounterWrite => Ok(Arc::new(
             CounterWriteOperationFactory::new(settings, session, workload_factory, stats).await?,
         )),
         Command::CounterRead => Ok(Arc::new(
-            CounterReadOperationFactory::new(
-                DEFAULT_COUNTER_TABLE_NAME,
-                settings,
-                session,
-                workload_factory,
-                stats,
-            )
-            .await?,
+            CounterReadOperationFactory::new(settings, session, workload_factory, stats).await?,
         )),
         cmd => Err(anyhow::anyhow!(
             "Runtime for command '{}' not implemented yet.",

--- a/src/bin/cql-stress-cassandra-stress/operation/counter_write.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/counter_write.rs
@@ -2,27 +2,19 @@ use anyhow::{Context, Result};
 
 use std::{ops::ControlFlow, sync::Arc};
 
-use cql_stress::{
-    configuration::{Operation, OperationContext, OperationFactory},
-    make_runnable,
-};
 use scylla::frame::response::result::CqlValue;
 use scylla::frame::value::Counter;
 use scylla::{prepared_statement::PreparedStatement, Session};
 
-use crate::{
-    java_generate::distribution::Distribution, settings::CassandraStressSettings,
-    stats::ShardedStats,
-};
+use crate::{java_generate::distribution::Distribution, settings::CassandraStressSettings};
 
-use super::{row_generator::RowGenerator, RowGeneratorFactory};
+use super::{
+    row_generator::RowGenerator, CassandraStressOperation, CassandraStressOperationFactory,
+};
 
 pub struct CounterWriteOperation {
     session: Arc<Session>,
     statement: PreparedStatement,
-    workload: RowGenerator,
-    max_operations: Option<u64>,
-    stats: Arc<ShardedStats>,
     non_pk_columns_count: usize,
     add_distribution: Box<dyn Distribution>,
 }
@@ -30,20 +22,46 @@ pub struct CounterWriteOperation {
 pub struct CounterWriteOperationFactory {
     session: Arc<Session>,
     statement: PreparedStatement,
-    workload_factory: RowGeneratorFactory,
-    max_operations: Option<u64>,
-    stats: Arc<ShardedStats>,
     settings: Arc<CassandraStressSettings>,
 }
 
-impl OperationFactory for CounterWriteOperationFactory {
-    fn create(&self) -> Box<dyn Operation> {
-        Box::new(CounterWriteOperation {
+impl CassandraStressOperation for CounterWriteOperation {
+    type Factory = CounterWriteOperationFactory;
+
+    async fn execute(&self, row: &[CqlValue]) -> Result<ControlFlow<()>> {
+        let result = self.session.execute(&self.statement, row).await;
+
+        if let Err(err) = result.as_ref() {
+            tracing::error!(
+                error = %err,
+                partition_key = ?row.last().unwrap(),
+                "counter write error",
+            );
+        }
+
+        result?;
+        Ok(ControlFlow::Continue(()))
+    }
+
+    fn generate_row(&self, row_generator: &mut RowGenerator) -> Vec<CqlValue> {
+        let mut values: Vec<CqlValue> = Vec::with_capacity(self.non_pk_columns_count + 1);
+
+        for _ in 0..self.non_pk_columns_count {
+            values.push(CqlValue::Counter(Counter(self.add_distribution.next_i64())))
+        }
+        let pk = row_generator.generate_pk();
+        values.push(pk);
+        values
+    }
+}
+
+impl CassandraStressOperationFactory for CounterWriteOperationFactory {
+    type Operation = CounterWriteOperation;
+
+    fn create(&self) -> Self::Operation {
+        CounterWriteOperation {
             session: Arc::clone(&self.session),
             statement: self.statement.clone(),
-            workload: self.workload_factory.create(),
-            max_operations: self.max_operations,
-            stats: Arc::clone(&self.stats),
             non_pk_columns_count: self.settings.column.columns.len(),
             add_distribution: self
                 .settings
@@ -53,30 +71,14 @@ impl OperationFactory for CounterWriteOperationFactory {
                 .unwrap()
                 .add_distribution
                 .create(),
-        })
+        }
     }
 }
 
 impl CounterWriteOperationFactory {
-    fn build_query(settings: &Arc<CassandraStressSettings>) -> String {
-        // Assuming there are non-pk columns [C0, C1, C2], it generates:
-        // "C0"="C0"+?,"C1"="C1"+?,"C2"="C2"+?
-        let columns_str = settings
-            .column
-            .columns
-            .iter()
-            .map(|col| format!("\"{0}\"=\"{0}\"+?", col))
-            .collect::<Vec<_>>()
-            .join(",");
-
-        format!("UPDATE counter1 SET {} WHERE KEY=?", columns_str)
-    }
-
     pub async fn new(
         settings: Arc<CassandraStressSettings>,
         session: Arc<Session>,
-        workload_factory: RowGeneratorFactory,
-        stats: Arc<ShardedStats>,
     ) -> Result<Self> {
         // UPDATE counter1 SET "C0"="C0"+?,"C1"="C1"+?,"C2"="C2"+?,"C3"="C3"+?,"C4"="C4"+? WHERE KEY=?
         let statement_str = Self::build_query(&settings);
@@ -94,45 +96,21 @@ impl CounterWriteOperationFactory {
         Ok(Self {
             session,
             statement,
-            workload_factory,
-            max_operations: settings.command_params.common.operation_count,
-            stats,
             settings: Arc::clone(&settings),
         })
     }
-}
 
-make_runnable!(CounterWriteOperation);
-impl CounterWriteOperation {
-    async fn execute(&mut self, ctx: &OperationContext) -> Result<ControlFlow<()>> {
-        if self
-            .max_operations
-            .is_some_and(|max_ops| ctx.operation_id >= max_ops)
-        {
-            return Ok(ControlFlow::Break(()));
-        }
+    fn build_query(settings: &Arc<CassandraStressSettings>) -> String {
+        // Assuming there are non-pk columns [C0, C1, C2], it generates:
+        // "C0"="C0"+?,"C1"="C1"+?,"C2"="C2"+?
+        let columns_str = settings
+            .column
+            .columns
+            .iter()
+            .map(|col| format!("\"{0}\"=\"{0}\"+?", col))
+            .collect::<Vec<_>>()
+            .join(",");
 
-        let mut values: Vec<CqlValue> = Vec::with_capacity(self.non_pk_columns_count + 1);
-
-        for _ in 0..self.non_pk_columns_count {
-            values.push(CqlValue::Counter(Counter(self.add_distribution.next_i64())))
-        }
-        let pk = self.workload.generate_pk();
-        values.push(pk);
-
-        let result = self.session.execute(&self.statement, &values).await;
-
-        if let Err(err) = result.as_ref() {
-            tracing::error!(
-                error = %err,
-                partition_key = ?values.last().unwrap(),
-                "counter write error",
-            );
-        }
-
-        self.stats.get_shard_mut().account_operation(ctx, &result);
-        result?;
-
-        Ok(ControlFlow::Continue(()))
+        format!("UPDATE counter1 SET {} WHERE KEY=?", columns_str)
     }
 }

--- a/src/bin/cql-stress-cassandra-stress/operation/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/mod.rs
@@ -4,7 +4,15 @@ mod row_generator;
 mod write;
 
 use anyhow::Result;
+use cql_stress::configuration::Operation;
+use cql_stress::configuration::OperationContext;
+use cql_stress::configuration::OperationFactory;
+use cql_stress::make_runnable;
+use scylla::Session;
+use std::future::Future;
 use std::num::Wrapping;
+use std::ops::ControlFlow;
+use std::sync::Arc;
 
 pub use counter_write::CounterWriteOperationFactory;
 pub use read::CounterReadOperationFactory;
@@ -15,6 +23,113 @@ use scylla::{
     QueryResult,
 };
 pub use write::WriteOperationFactory;
+
+use crate::stats::ShardedStats;
+
+use self::row_generator::RowGenerator;
+
+/// A specific CassandraStress operation.
+///
+/// The operation implementing this trait should handle
+/// sending the actual query to the database.
+///
+/// This trait is intended to be used by [`GenericCassandraStressOperation`]
+/// which encapsulates the specific operation and handles the common logic.
+///
+/// ## Result of [`CassandraStressOperation::execute`]
+/// ### Operation retries
+/// During the operation retry (i.e. when `execute` returned and error),
+/// we will make use of the same row that we originally used in the previous try.
+///
+/// We only generate a new row ([`CassandraStressOperation::generate_row`])
+/// during the first try to perform an operation.
+/// ### Stats recording
+/// The result of `execute` is recorded
+/// to [`ShardedStats`] - even if the operation failed, so we keep track
+/// of number of errors that appeared during the benchmark.
+pub trait CassandraStressOperation: Sync + Send {
+    type Factory: CassandraStressOperationFactory<Operation = Self>;
+
+    fn execute(&self, row: &[CqlValue]) -> impl Future<Output = Result<ControlFlow<()>>> + Send;
+    fn generate_row(&self, row_generator: &mut RowGenerator) -> Vec<CqlValue>;
+}
+
+pub trait CassandraStressOperationFactory: Sync + Send + Sized {
+    type Operation: CassandraStressOperation<Factory = Self>;
+
+    fn create(&self) -> Self::Operation;
+}
+
+/// Generic CassandraStress operation.
+///
+/// It handles the common logic for all of the operations, such as:
+/// - checking whether `max_operations` operations have already been performed
+/// - caching the row for operation retries
+/// - recording operation result to statistics structure
+///
+/// Delegates the specific logic to `cs_operation`.
+pub struct GenericCassandraStressOperation<O: CassandraStressOperation> {
+    cs_operation: O,
+    stats: Arc<ShardedStats>,
+    workload: RowGenerator,
+    max_operations: Option<u64>,
+    // The operation may need to be retried.
+    // This is why we cache the row so it can be used
+    // during the retry.
+    cached_row: Option<Vec<CqlValue>>,
+}
+
+make_runnable!(GenericCassandraStressOperation<O: CassandraStressOperation>);
+impl<O: CassandraStressOperation> GenericCassandraStressOperation<O> {
+    async fn execute(&mut self, ctx: &OperationContext) -> Result<ControlFlow<()>> {
+        if self
+            .max_operations
+            .is_some_and(|max_ops| ctx.operation_id >= max_ops)
+        {
+            return Ok(ControlFlow::Break(()));
+        }
+
+        let row = self
+            .cached_row
+            .get_or_insert_with(|| self.cs_operation.generate_row(&mut self.workload));
+
+        let op_result = self.cs_operation.execute(row).await;
+        self.stats
+            .get_shard_mut()
+            .account_operation(ctx, &op_result);
+
+        if op_result.is_ok() {
+            // Operation was successful - we will generate new row
+            // for the next operation.
+            self.cached_row = None;
+        }
+
+        op_result
+    }
+}
+
+pub struct GenericCassandraStressOperationFactory<O: CassandraStressOperation> {
+    cs_operation_factory: O::Factory,
+    workload_factory: RowGeneratorFactory,
+    max_operations: Option<u64>,
+    stats: Arc<ShardedStats>,
+}
+
+impl<O: CassandraStressOperation + 'static> OperationFactory
+    for GenericCassandraStressOperationFactory<O>
+{
+    fn create(&self) -> Box<dyn Operation> {
+        let cs_operation = self.cs_operation_factory.create();
+
+        Box::new(GenericCassandraStressOperation {
+            cs_operation,
+            stats: Arc::clone(&self.stats),
+            workload: self.workload_factory.create(),
+            max_operations: self.max_operations,
+            cached_row: None,
+        })
+    }
+}
 
 /// See https://github.com/scylladb/scylla-tools-java/blob/master/tools/stress/src/org/apache/cassandra/stress/generate/PartitionIterator.java#L725.
 fn recompute_seed(seed: i64, partition_key: &CqlValue) -> i64 {

--- a/src/bin/cql-stress-cassandra-stress/operation/read.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/read.rs
@@ -1,103 +1,34 @@
 use std::{marker::PhantomData, ops::ControlFlow, sync::Arc};
 
-use cql_stress::{
-    configuration::{Operation, OperationContext, OperationFactory},
-    make_runnable,
-};
-
 use anyhow::{Context, Result};
 use scylla::{frame::response::result::CqlValue, prepared_statement::PreparedStatement, Session};
 
-use crate::{settings::CassandraStressSettings, stats::ShardedStats};
+use crate::settings::CassandraStressSettings;
 
 use super::{
-    row_generator::{RowGenerator, RowGeneratorFactory},
+    row_generator::RowGenerator, CassandraStressOperation, CassandraStressOperationFactory,
     EqualRowValidator, ExistsRowValidator, RowValidator,
 };
 
 pub struct ReadOperation<V: RowValidator> {
     session: Arc<Session>,
     statement: PreparedStatement,
-    workload: RowGenerator,
-    max_operations: Option<u64>,
-    stats: Arc<ShardedStats>,
     row_validator: V,
 }
 
 pub struct GenericReadOperationFactory<V: RowValidator> {
     session: Arc<Session>,
     statement: PreparedStatement,
-    workload_factory: RowGeneratorFactory,
-    max_operations: Option<u64>,
-    stats: Arc<ShardedStats>,
     _phantom: PhantomData<V>,
 }
 
+pub type RegularReadOperation = ReadOperation<EqualRowValidator>;
 pub type RegularReadOperationFactory = GenericReadOperationFactory<EqualRowValidator>;
+
+pub type CounterReadOperation = ReadOperation<ExistsRowValidator>;
 pub type CounterReadOperationFactory = GenericReadOperationFactory<ExistsRowValidator>;
 
-impl<V: RowValidator + 'static> OperationFactory for GenericReadOperationFactory<V> {
-    fn create(&self) -> Box<dyn Operation> {
-        Box::new(ReadOperation::<V> {
-            session: Arc::clone(&self.session),
-            statement: self.statement.clone(),
-            workload: self.workload_factory.create(),
-            max_operations: self.max_operations,
-            stats: Arc::clone(&self.stats),
-            row_validator: Default::default(),
-        })
-    }
-}
-
-impl<V: RowValidator> GenericReadOperationFactory<V> {
-    pub async fn new(
-        table_name: &'static str,
-        settings: Arc<CassandraStressSettings>,
-        session: Arc<Session>,
-        workload_factory: RowGeneratorFactory,
-        stats: Arc<ShardedStats>,
-    ) -> Result<Self> {
-        let statement_str = format!("SELECT * FROM {} WHERE KEY=?", table_name);
-        let mut statement = session
-            .prepare(statement_str)
-            .await
-            .context("Failed to prepare statement")?;
-
-        statement.set_is_idempotent(true);
-        statement.set_consistency(settings.command_params.common.consistency_level);
-        statement.set_serial_consistency(Some(
-            settings.command_params.common.serial_consistency_level,
-        ));
-
-        Ok(Self {
-            session,
-            statement,
-            workload_factory,
-            max_operations: settings.command_params.common.operation_count,
-            stats,
-            _phantom: PhantomData,
-        })
-    }
-}
-
-make_runnable!(ReadOperation<V: RowValidator>);
 impl<V: RowValidator> ReadOperation<V> {
-    async fn execute(&mut self, ctx: &OperationContext) -> Result<ControlFlow<()>> {
-        if self
-            .max_operations
-            .is_some_and(|max_ops| ctx.operation_id >= max_ops)
-        {
-            return Ok(ControlFlow::Break(()));
-        }
-
-        let row = self.workload.generate_row();
-        let result = self.do_execute(&row).await;
-
-        self.stats.get_shard_mut().account_operation(ctx, &result);
-
-        result
-    }
-
     async fn do_execute(&self, row: &[CqlValue]) -> Result<ControlFlow<()>> {
         let pk = &row[0];
 
@@ -122,5 +53,55 @@ impl<V: RowValidator> ReadOperation<V> {
             .with_context(|| format!("Row with partition_key: {:?} could not be validated.", pk))?;
 
         Ok(ControlFlow::Continue(()))
+    }
+}
+
+impl<V: RowValidator> CassandraStressOperation for ReadOperation<V> {
+    type Factory = GenericReadOperationFactory<V>;
+
+    async fn execute(&self, row: &[CqlValue]) -> Result<ControlFlow<()>> {
+        self.do_execute(row).await
+    }
+
+    fn generate_row(&self, row_generator: &mut RowGenerator) -> Vec<CqlValue> {
+        row_generator.generate_row()
+    }
+}
+
+impl<V: RowValidator> CassandraStressOperationFactory for GenericReadOperationFactory<V> {
+    type Operation = ReadOperation<V>;
+
+    fn create(&self) -> Self::Operation {
+        ReadOperation {
+            session: Arc::clone(&self.session),
+            statement: self.statement.clone(),
+            row_validator: Default::default(),
+        }
+    }
+}
+
+impl<V: RowValidator> GenericReadOperationFactory<V> {
+    pub async fn new(
+        settings: Arc<CassandraStressSettings>,
+        session: Arc<Session>,
+        stressed_table_name: &'static str,
+    ) -> Result<Self> {
+        let statement_str = format!("SELECT * FROM {} WHERE KEY=?", stressed_table_name);
+        let mut statement = session
+            .prepare(statement_str)
+            .await
+            .context("Failed to prepare statement")?;
+
+        statement.set_is_idempotent(true);
+        statement.set_consistency(settings.command_params.common.consistency_level);
+        statement.set_serial_consistency(Some(
+            settings.command_params.common.serial_consistency_level,
+        ));
+
+        Ok(Self {
+            session,
+            statement,
+            _phantom: PhantomData,
+        })
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/scylladb/cql-stress/issues/67

## Motivation

Currently, the common logic for operations is repeated. The idea is to introduce an additional struct that will handle the common logic and encapsulate the logic of specific c-s operation.

This will also help to implement `mixed` operation. This is why, we should merge it before https://github.com/scylladb/cql-stress/pull/63.

## Solution

Introduced a `CassandraStressOperation` trait which represents a specific c-s operation.
The `GenericCassandraStressOperation` structure will handle the common logic and delegate
the specific operation logic to some object implementing `CassandraStressOperation`.

The common logic that was extracted to `GenericCassandraStressOperation`:
- checks whether `operation_id` > `max_operations`. If true, the stress test will be terminated
- recording operation result to stats structure
- caching the row for retries (https://github.com/scylladb/cql-stress/issues/67)