### PR TITLE
c-s population: support `seq=x..y` bash-friendly syntax

### DIFF
--- a/src/bin/cql-stress-cassandra-stress/settings/cs_args_bad_test.in
+++ b/src/bin/cql-stress-cassandra-stress/settings/cs_args_bad_test.in
@@ -22,6 +22,9 @@ cassandra-stress write -col size=SEQ(1..10,50)
 cassandra-stress write -col names=foo,bar,baz n=3
 cassandra-stress write -pop dist=foo
 cassandra-stress write -pop dist=SEQ(1..10,50)
+cassandra-stress write -pop dist=SEQ(1..10) seq=1..10
+cassandra-stress write -pop seq=aa..bb
+cassandra-stress write -pop seq=1.10
 cassandra-stress write add=FIXED(10)
 
 # Keysize must be a positive number.

--- a/src/bin/cql-stress-cassandra-stress/settings/cs_args_good_test.in
+++ b/src/bin/cql-stress-cassandra-stress/settings/cs_args_good_test.in
@@ -31,6 +31,7 @@ cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1, key=value)
 cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1, key=value) -rate threads=10 -col size=FIXED(50) -pop dist=SEQ(1..10)
 cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1, key=value) -rate threads=10 -col size=FIXED(50) -pop dist=UNIFORM(1..10)
 cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1, key=value) -rate threads=10 -col size=fixed(50) -pop dist=UNIFORM(1..10)
+cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1, key=value) -rate threads=10 -col size=fixed(50) -pop seq=1..100
 
 # This tests the case sensitivity of throttle= parameter's value. We should accept both /S and /s.
 cassandra-stress read no-warmup cl=QUORUM duration=600M -rate threads=80 throttle=8000/S


### PR DESCRIPTION
# Motivation

In SCT, the bash-friendly `-pop seq=1..100` syntax is broadly used (equivalent to `-pop 'dist=SEQ(1..100)` syntax).
This is why we extend the CLI so c-s frontend supports such syntax.