### PR TITLE
User command: parsing logic + schema creation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,7 @@ jobs:
       run: cargo build --verbose --tests --features "user-profile"
     - name: Run tests
       # test threads must be one because else database tests will run in parallel and will result in flaky tests
-      run: cargo test --verbose -- --test-threads=1
+      run: cargo test --verbose --features "user-profile" -- --test-threads=1
     - name: Install python driver
       run: pip install scylla-driver
     - name: Install pytest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,10 +25,12 @@ jobs:
     - uses: actions/checkout@v2
     - name: Format check
       run: cargo fmt --verbose --all -- --check
-    - name: Clippy check
+    - name: Clippy check with no features
       run: cargo clippy --verbose --tests -- -D warnings
+    - name: Clippy check with `user-profile` feature
+      run: cargo clippy --verbose --tests --features "user-profile" -- -D warnings
     - name: Build
-      run: cargo build --verbose --tests
+      run: cargo build --verbose --tests --features "user-profile"
     - name: Run tests
       # test threads must be one because else database tests will run in parallel and will result in flaky tests
       run: cargo test --verbose -- --test-threads=1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,8 @@ dependencies = [
  "regex",
  "rust-strictmath",
  "scylla",
+ "serde",
+ "serde_yaml",
  "sha2",
  "strum 0.25.0",
  "strum_macros 0.25.1",
@@ -583,6 +585,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +651,12 @@ name = "libm"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1132,6 +1150,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
 
 [[package]]
+name = "ryu"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,6 +1230,32 @@ name = "serde"
 version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.101",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
+dependencies = [
+ "indexmap",
+ "ryu",
+ "serde",
+ "yaml-rust",
+]
 
 [[package]]
 name = "sha2"
@@ -1837,3 +1887,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ tokio = { version = "1.15.0", features = [
 tracing = "0.1.35"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 rust-strictmath = "0.1.1"
+serde = { version = "1.0", features = ["derive"] }
+serde_yaml = "0.8"
 
 [dev-dependencies]
 ntest = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,11 @@ tokio = { version = "1.15.0", features = [
 tracing = "0.1.35"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 rust-strictmath = "0.1.1"
-serde = { version = "1.0", features = ["derive"] }
-serde_yaml = "0.8"
+serde = { version = "1.0", features = ["derive"], optional = true }
+serde_yaml = {version = "0.8", optional = true }
+
+[features]
+user-profile = ["dep:serde", "dep:serde_yaml"]
 
 [dev-dependencies]
 ntest = "0.8"

--- a/src/bin/cql-stress-cassandra-stress/main.rs
+++ b/src/bin/cql-stress-cassandra-stress/main.rs
@@ -163,6 +163,7 @@ async fn prepare_run(
 
 async fn create_schema(session: &Session, settings: &CassandraStressSettings) -> Result<()> {
     match settings.command {
+        #[cfg(feature = "user-profile")]
         Command::User => {
             // 'user' command provided. This unwrap is safe.
             settings

--- a/src/bin/cql-stress-cassandra-stress/settings/command/common.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/common.rs
@@ -385,6 +385,7 @@ pub fn parse_common_params(cmd: &Command, payload: &mut ParsePayload) -> Result<
         common: parse_with_handles(handles),
         counter: None,
         mixed: None,
+        user: None,
     })
 }
 

--- a/src/bin/cql-stress-cassandra-stress/settings/command/common.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/common.rs
@@ -385,6 +385,7 @@ pub fn parse_common_params(cmd: &Command, payload: &mut ParsePayload) -> Result<
         common: parse_with_handles(handles),
         counter: None,
         mixed: None,
+        #[cfg(feature = "user-profile")]
         user: None,
     })
 }

--- a/src/bin/cql-stress-cassandra-stress/settings/command/counter.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/counter.rs
@@ -29,6 +29,7 @@ impl CounterParams {
                 add_distribution: add_distribution.get().unwrap(),
             }),
             mixed: None,
+            #[cfg(feature = "user-profile")]
             user: None,
         })
     }

--- a/src/bin/cql-stress-cassandra-stress/settings/command/counter.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/counter.rs
@@ -29,6 +29,7 @@ impl CounterParams {
                 add_distribution: add_distribution.get().unwrap(),
             }),
             mixed: None,
+            user: None,
         })
     }
 }

--- a/src/bin/cql-stress-cassandra-stress/settings/command/counter.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/counter.rs
@@ -72,7 +72,7 @@ fn prepare_parser(
     let mut counter_payload = add_counter_param_groups(&mut parser);
 
     for group in counter_payload.groups.iter_mut() {
-        parser.group(&group.iter().map(|e| e.as_ref()).collect::<Vec<_>>())
+        parser.group_iter(group.iter().map(|e| e.as_ref()))
     }
 
     (

--- a/src/bin/cql-stress-cassandra-stress/settings/command/mixed.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/mixed.rs
@@ -165,7 +165,7 @@ fn prepare_parser(
     for group in counter_payload.groups.iter_mut() {
         group.push(Box::new(operation_ratio.clone()));
         group.push(Box::new(clustering.clone()));
-        parser.group(&group.iter().map(|e| e.as_ref()).collect::<Vec<_>>())
+        parser.group_iter(group.iter().map(|e| e.as_ref()))
     }
 
     (

--- a/src/bin/cql-stress-cassandra-stress/settings/command/mixed.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/mixed.rs
@@ -138,6 +138,7 @@ impl MixedParams {
                 operation_ratio: mixed_handles.operation_ratio.get().unwrap(),
                 clustering: mixed_handles.clustering.get().unwrap(),
             }),
+            #[cfg(feature = "user-profile")]
             user: None,
         })
     }

--- a/src/bin/cql-stress-cassandra-stress/settings/command/mixed.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/mixed.rs
@@ -138,6 +138,7 @@ impl MixedParams {
                 operation_ratio: mixed_handles.operation_ratio.get().unwrap(),
                 clustering: mixed_handles.clustering.get().unwrap(),
             }),
+            user: None,
         })
     }
 }

--- a/src/bin/cql-stress-cassandra-stress/settings/command/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/mod.rs
@@ -13,6 +13,7 @@ mod common;
 mod counter;
 mod help;
 mod mixed;
+mod user;
 
 use self::common::{parse_common_params, print_help_common};
 use self::counter::print_help_counter;

--- a/src/bin/cql-stress-cassandra-stress/settings/command/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/mod.rs
@@ -20,6 +20,7 @@ use self::counter::print_help_counter;
 use self::counter::CounterParams;
 use self::mixed::print_help_mixed;
 use self::mixed::MixedParams;
+use self::user::UserParams;
 pub use help::print_help;
 
 use super::ParsePayload;
@@ -98,6 +99,7 @@ pub struct CommandParams {
     pub common: CommonParams,
     pub counter: Option<CounterParams>,
     pub mixed: Option<MixedParams>,
+    pub user: Option<UserParams>,
 }
 
 impl CommandParams {

--- a/src/bin/cql-stress-cassandra-stress/settings/command/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/mod.rs
@@ -39,6 +39,7 @@ pub enum Command {
     CounterWrite,
     CounterRead,
     Mixed,
+    User,
 }
 
 impl Command {
@@ -53,6 +54,7 @@ impl Command {
             }
             Command::CounterWrite => Ok(Some(CounterParams::parse(self, payload)?)),
             Command::Mixed => Ok(Some(MixedParams::parse(self, payload)?)),
+            Command::User => Ok(Some(UserParams::parse(self, payload)?)),
             Command::Help => {
                 parse_help_command(payload)?;
                 Ok(None)
@@ -71,6 +73,7 @@ impl Command {
             Command::CounterWrite => "Multiple concurrent updates of counters.",
             Command::CounterRead => "Multiple concurrent reads of counters. The cluster must first be populated by a counterwrite test.",
             Command::Mixed => "Interleaving of any basic commands, with configurable ratio and distribution - the cluster must first be populated by a write test.",
+            Command::User => "Interleaving of user provided queries, with configurable ratio and distribution - the cluster must first be populated by a write test.",
             Command::Help => "Print help for a command or option",
         };
 
@@ -89,6 +92,7 @@ impl Command {
             Command::Read | Command::Write | Command::CounterRead => print_help_common(self.show()),
             Command::CounterWrite => print_help_counter(self.show()),
             Command::Mixed => print_help_mixed(self.show()),
+            Command::User => UserParams::print_help(self.show()),
             Command::Help => help::print_help(),
         }
     }

--- a/src/bin/cql-stress-cassandra-stress/settings/command/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/mod.rs
@@ -13,6 +13,7 @@ mod common;
 mod counter;
 mod help;
 mod mixed;
+#[cfg(feature = "user-profile")]
 mod user;
 
 use self::common::{parse_common_params, print_help_common};
@@ -20,6 +21,7 @@ use self::counter::print_help_counter;
 use self::counter::CounterParams;
 use self::mixed::print_help_mixed;
 use self::mixed::MixedParams;
+#[cfg(feature = "user-profile")]
 use self::user::UserParams;
 pub use help::print_help;
 
@@ -39,6 +41,7 @@ pub enum Command {
     CounterWrite,
     CounterRead,
     Mixed,
+    #[cfg(feature = "user-profile")]
     User,
 }
 
@@ -54,6 +57,7 @@ impl Command {
             }
             Command::CounterWrite => Ok(Some(CounterParams::parse(self, payload)?)),
             Command::Mixed => Ok(Some(MixedParams::parse(self, payload)?)),
+            #[cfg(feature = "user-profile")]
             Command::User => Ok(Some(UserParams::parse(self, payload)?)),
             Command::Help => {
                 parse_help_command(payload)?;
@@ -73,6 +77,7 @@ impl Command {
             Command::CounterWrite => "Multiple concurrent updates of counters.",
             Command::CounterRead => "Multiple concurrent reads of counters. The cluster must first be populated by a counterwrite test.",
             Command::Mixed => "Interleaving of any basic commands, with configurable ratio and distribution - the cluster must first be populated by a write test.",
+            #[cfg(feature = "user-profile")]
             Command::User => "Interleaving of user provided queries, with configurable ratio and distribution - the cluster must first be populated by a write test.",
             Command::Help => "Print help for a command or option",
         };
@@ -92,6 +97,7 @@ impl Command {
             Command::Read | Command::Write | Command::CounterRead => print_help_common(self.show()),
             Command::CounterWrite => print_help_counter(self.show()),
             Command::Mixed => print_help_mixed(self.show()),
+            #[cfg(feature = "user-profile")]
             Command::User => UserParams::print_help(self.show()),
             Command::Help => help::print_help(),
         }
@@ -103,6 +109,7 @@ pub struct CommandParams {
     pub common: CommonParams,
     pub counter: Option<CounterParams>,
     pub mixed: Option<MixedParams>,
+    #[cfg(feature = "user-profile")]
     pub user: Option<UserParams>,
 }
 

--- a/src/bin/cql-stress-cassandra-stress/settings/command/test_user_profile_yamls/empty_queries_profile.yaml
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/test_user_profile_yamls/empty_queries_profile.yaml
@@ -1,0 +1,4 @@
+# This file is invalid since it has an empty `queries` map.
+keyspace: foo
+table: bar
+queries:

--- a/src/bin/cql-stress-cassandra-stress/settings/command/test_user_profile_yamls/full_profile.yaml
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/test_user_profile_yamls/full_profile.yaml
@@ -1,0 +1,24 @@
+# This file represents full set of supported parameters.
+keyspace: keyspace2
+
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS keyspace2 WITH replication = { 'class': 'SimpleStrategy', 'replication_factor': 1};
+
+table: standard1
+
+table_definition:
+  CREATE TABLE IF NOT EXISTS standard1 (
+    pkey blob PRIMARY KEY,
+    ckey blob,
+    c1 blob
+   );
+
+queries:
+  ins:
+    cql: insert into standard1 (pkey, ckey, c1) values (?, ?, ?)
+    consistencyLevel: local
+    serialConsistencyLevel: local_serial
+  read:
+    cql: select c1 from standard1 where pkey = ?
+    consistencyLevel: quorum
+    serialConsistencyLevel: serial

--- a/src/bin/cql-stress-cassandra-stress/settings/command/test_user_profile_yamls/minimal_profile.yaml
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/test_user_profile_yamls/minimal_profile.yaml
@@ -1,0 +1,6 @@
+# This file contains the minimal set of parameters required by the tool.
+keyspace: foo
+table: bar
+queries:
+  baz:
+    cql: select c1 from standard1 where pkey = ?

--- a/src/bin/cql-stress-cassandra-stress/settings/command/test_user_profile_yamls/missing_keyspace_profile.yaml
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/test_user_profile_yamls/missing_keyspace_profile.yaml
@@ -1,0 +1,5 @@
+# This file is invalid since it's missing a keyspace name.
+table: bar
+queries:
+  baz:
+    cql: select c1 from standard1 where pkey = ?

--- a/src/bin/cql-stress-cassandra-stress/settings/command/test_user_profile_yamls/unknown_field_profile.yaml
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/test_user_profile_yamls/unknown_field_profile.yaml
@@ -1,0 +1,2 @@
+# This file contains unknown parameter "foo_param", and so is invalid
+foo_param: keyspace1

--- a/src/bin/cql-stress-cassandra-stress/settings/command/test_user_profile_yamls/unknown_query_field_profile.yaml
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/test_user_profile_yamls/unknown_query_field_profile.yaml
@@ -1,0 +1,7 @@
+# This file contains the unknown parameter "foo" of "baz" query, and so is invalid
+keyspace: foo
+table: bar
+queries:
+  baz:
+    cql: select c1 from standard1 where pkey = ?
+    foo: local_serial

--- a/src/bin/cql-stress-cassandra-stress/settings/command/user.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/user.rs
@@ -1,0 +1,21 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, PartialEq, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct UserProfile {
+    pub keyspace: String,
+    pub keyspace_definition: Option<String>,
+    pub table: String,
+    pub table_definition: Option<String>,
+    pub queries: HashMap<String, QueryDefinitionYaml>,
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Debug)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct QueryDefinitionYaml {
+    pub cql: String,
+    pub consistency_level: Option<String>,
+    pub serial_consistency_level: Option<String>,
+}

--- a/src/bin/cql-stress-cassandra-stress/settings/command/user.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/user.rs
@@ -1,6 +1,9 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, fs::File};
 
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+
+use crate::settings::param::types::Parsable;
 
 #[derive(Deserialize, Serialize, PartialEq, Debug)]
 #[serde(deny_unknown_fields)]
@@ -18,4 +21,20 @@ pub struct QueryDefinitionYaml {
     pub cql: String,
     pub consistency_level: Option<String>,
     pub serial_consistency_level: Option<String>,
+}
+
+impl Parsable for UserProfile {
+    type Parsed = Self;
+
+    fn parse(s: &str) -> Result<Self::Parsed> {
+        let yaml =
+            File::open(s).with_context(|| format!("Invalid profile yaml filepath: {}", s))?;
+        let profile: UserProfile =
+            serde_yaml::from_reader(yaml).context("Failed to parse profile yaml file")?;
+        anyhow::ensure!(
+            !profile.queries.is_empty(),
+            "'queries' map cannot be empty. Please define at least one query."
+        );
+        Ok(profile)
+    }
 }

--- a/src/bin/cql-stress-cassandra-stress/settings/command/user.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/user.rs
@@ -4,9 +4,15 @@ use anyhow::{Context, Result};
 use scylla::statement::{Consistency, SerialConsistency};
 use serde::{Deserialize, Serialize};
 
-use crate::settings::param::types::Parsable;
+use crate::settings::{
+    param::{types::Parsable, ParamsParser, SimpleParamHandle},
+    ParsePayload,
+};
 
-use super::common::{ConsistencyLevel, SerialConsistencyLevel};
+use super::{
+    common::{CommonParamHandles, ConsistencyLevel, SerialConsistencyLevel},
+    Command, CommandParams,
+};
 
 #[derive(Deserialize, Serialize, PartialEq, Debug)]
 #[serde(deny_unknown_fields)]
@@ -74,4 +80,77 @@ pub struct UserParams {
     pub table: String,
     pub table_definition: Option<String>,
     pub queries: HashMap<String, QueryDefinition>,
+}
+
+impl UserParams {
+    pub fn parse(cmd: &Command, payload: &mut ParsePayload) -> Result<CommandParams> {
+        let args = payload.remove(cmd.show()).unwrap_or_default();
+        let (parser, common_handles, user_handles) = prepare_parser(cmd.show());
+        parser.parse(args)?;
+        Ok(CommandParams {
+            common: super::common::parse_with_handles(common_handles),
+            counter: None,
+            mixed: None,
+            user: Some(Self::parse_with_handles(user_handles)?),
+        })
+    }
+
+    pub fn print_help(command_str: &str) {
+        let (parser, _, _) = prepare_parser(command_str);
+        parser.print_help();
+    }
+
+    fn parse_with_handles(handles: UserParamHandles) -> Result<Self> {
+        // 'profile' is a required parameter. This unwrap is safe since parsing was successful.
+        let UserProfile {
+            keyspace,
+            keyspace_definition,
+            table,
+            table_definition,
+            queries,
+        } = handles.profile.get().unwrap();
+
+        let queries = queries
+            .into_iter()
+            .map(|(query_name, query_def)| {
+                let query_def = query_def.into_query_definition();
+                match query_def {
+                    Ok(query_def) => Ok((query_name, query_def)),
+                    Err(e) => Err(e.context("Failed to parse query definition")),
+                }
+            })
+            .collect::<Result<HashMap<_, _>, _>>()?;
+
+        Ok(Self {
+            keyspace,
+            keyspace_definition,
+            table,
+            table_definition,
+            queries,
+        })
+    }
+}
+
+struct UserParamHandles {
+    profile: SimpleParamHandle<UserProfile>,
+}
+
+fn prepare_parser(cmd: &str) -> (ParamsParser, CommonParamHandles, UserParamHandles) {
+    let mut parser = ParamsParser::new(cmd);
+
+    let (mut groups, common_handles) = super::common::add_common_param_groups(&mut parser);
+
+    let profile = parser.simple_param(
+        "profile=",
+        None,
+        "Specify the path to a yaml cql3 profile",
+        true,
+    );
+
+    for group in groups.iter_mut() {
+        group.push(Box::new(profile.clone()));
+        parser.group_iter(group.iter().map(|e| e.as_ref()));
+    }
+
+    (parser, common_handles, UserParamHandles { profile })
 }

--- a/src/bin/cql-stress-cassandra-stress/settings/command/user.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/user.rs
@@ -1,9 +1,12 @@
 use std::{collections::HashMap, fs::File};
 
 use anyhow::{Context, Result};
+use scylla::statement::{Consistency, SerialConsistency};
 use serde::{Deserialize, Serialize};
 
 use crate::settings::param::types::Parsable;
+
+use super::common::{ConsistencyLevel, SerialConsistencyLevel};
 
 #[derive(Deserialize, Serialize, PartialEq, Debug)]
 #[serde(deny_unknown_fields)]
@@ -21,6 +24,32 @@ pub struct QueryDefinitionYaml {
     pub cql: String,
     pub consistency_level: Option<String>,
     pub serial_consistency_level: Option<String>,
+}
+
+impl QueryDefinitionYaml {
+    fn into_query_definition(self) -> Result<QueryDefinition> {
+        let cql = self.cql;
+        let consistency = self
+            .consistency_level
+            .map(|c| ConsistencyLevel::parse(&c))
+            .transpose()?;
+        let serial_consistency = self
+            .serial_consistency_level
+            .map(|sc| SerialConsistencyLevel::parse(&sc))
+            .transpose()?;
+
+        Ok(QueryDefinition {
+            cql,
+            consistency,
+            serial_consistency,
+        })
+    }
+}
+
+pub struct QueryDefinition {
+    pub cql: String,
+    pub consistency: Option<Consistency>,
+    pub serial_consistency: Option<SerialConsistency>,
 }
 
 impl Parsable for UserProfile {

--- a/src/bin/cql-stress-cassandra-stress/settings/command/user.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/user.rs
@@ -67,3 +67,11 @@ impl Parsable for UserProfile {
         Ok(profile)
     }
 }
+
+pub struct UserParams {
+    pub keyspace: String,
+    pub keyspace_definition: Option<String>,
+    pub table: String,
+    pub table_definition: Option<String>,
+    pub queries: HashMap<String, QueryDefinition>,
+}

--- a/src/bin/cql-stress-cassandra-stress/settings/param/parser.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/parser.rs
@@ -192,8 +192,13 @@ impl ParamsParser {
 
     /// Creates a new group of the parameters.
     pub fn group(&mut self, params: &[&dyn ParamHandle]) {
+        self.group_iter(params.iter().copied())
+    }
+
+    /// Creates a new group of the parameters.
+    pub fn group_iter<'a>(&mut self, params: impl IntoIterator<Item = &'a dyn ParamHandle>) {
         self.groups.push(ParamsGroup::new(
-            params.iter().map(|handle| handle.cell()).collect(),
+            params.into_iter().map(|handle| handle.cell()).collect(),
         ))
     }
 


### PR DESCRIPTION
ref: https://cassandra.apache.org/doc/stable/cassandra/tools/cassandra_stress.html#user-mode

## Motivation

User command is the most complex c-s command. It is very flexible and allows user to define his own schema, as well as stress queries. We obviously want to support this command in cql-stress.

### User profiles
ref: https://cassandra.apache.org/doc/stable/cassandra/tools/cassandra_stress.html#profile

User can define the benchmark via profile yaml file. In this PR we introduce support for most commonly used profile parameters, which are:
- `keyspace`
- `keyspace_definition`
- `table`
- `table_definition`
- `queries`

## Changes 
- Introduced `UserParams` struct which contains the payload needed to run the benchmark
- Implemented CLI parsing logic for `user` command, which includes the `profile=` parameter that specifies the path to yaml file. Notice that c-s supports `ops` and `clustering=` parameters as well. These two define the ratio which we sample the specific `queries` from. As for now, I want to keep it simple and in the following PRs I plan to sample the operations in the round-robin fashion. We will introduce non-determinism in the future.
- Implemented the very basic runtime logic which prepares the schema for benchmark

## Tests
I think I could add some tests with exemplary yaml files. I'm not sure if it's a good idea since this would pollute our repo a bit (?). WDYT?