### PR TITLE
c-s/col: c-s compatibility for -col n= parameter

### DIFF
--- a/src/bin/cql-stress-cassandra-stress/settings/cs_args_bad_test.in
+++ b/src/bin/cql-stress-cassandra-stress/settings/cs_args_bad_test.in
@@ -29,6 +29,8 @@ cassandra-stress write -mode connectionsPerHost=3 connectionsPerShard=3
 cassandra-stress write -mode connectionPerShard=0
 cassandra-stress write -mode connectionPerShard=-1
 cassandra-stress write -mode compression=foo
+cassandra-stress write -col n=UNIFORM(1..10)
+cassandra-stress write -col n=FIXED(1..5)
 
 # One of the user/password is set, when the other one is not specified
 cassandra-stress write -mode user=cassandra

--- a/src/bin/cql-stress-cassandra-stress/settings/cs_args_good_test.in
+++ b/src/bin/cql-stress-cassandra-stress/settings/cs_args_good_test.in
@@ -25,6 +25,7 @@ cassandra-stress counter_write no-warmup add=UNIFORM(1..10) cl=THREE duration=20
 cassandra-stress counter_write no-warmup add=GAUSSIAN(1..10) cl=ANY duration=20m -schema replication(strategy=NetworkTopologyStrategy) keyspace=keyspace2
 cassandra-stress counter_write no-warmup add=FIXED(2) cl=ALL duration=20m -schema replication(replication_factor=3) keyspace=keyspace2
 cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1) -rate threads=10 -col n=10 size=UNIFORM(1..20)
+cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1) -rate threads=10 -col n=FIXED(10) size=UNIFORM(1..20)
 cassandra-stress read cl=QUORUM n=10000 -schema replication(key=value) -rate threads=10 -col names=foo,bar,baz
 cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1, key=value) -rate threads=10 -col size=FIXED(50)
 cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1, key=value) -rate threads=10 -col size=FIXED(50) -pop dist=SEQ(1..10)


### PR DESCRIPTION
Fixes: https://github.com/scylladb/cql-stress/issues/73

cassandra-stress supports a distribution syntax for `-col n=` parameter. However, it only allows the `FIXED(?)` distribution for cql mode.

Before this commit, cql-stress would accept a u64 value for the value of this parameter.

To make our CLI compatible with c-s (so it can be easily replaced in SCT), we will accept `FIXED(<u64>)` syntax as well.