### PR TITLE
Fix clippy errors

### DIFF
--- a/src/bin/cql-stress-scylla-bench/distribution.rs
+++ b/src/bin/cql-stress-scylla-bench/distribution.rs
@@ -8,6 +8,9 @@ pub type RngGen = Pcg64Mcg;
 
 pub trait Distribution: Send + Sync {
     fn get_u64(&self, rng: &mut RngGen) -> u64;
+
+    // TODO: Remove allow(dead_code) it when generator for floats is implemented.
+    #[allow(dead_code)]
     fn get_f64(&self, rng: &mut RngGen) -> f64 {
         self.get_u64(rng) as f64
     }


### PR DESCRIPTION
As of now, the get_f64 method of `Distribution` trait is unused. However, it will be used once the generators for float types are implemented.
Let's mark it with `#[allow(dead_code)]` until that happens to suppress clippy errors.