### PR TITLE
c-s: Generators for simple types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,7 @@ dependencies = [
  "java_random",
  "lazy_static",
  "ntest",
+ "num-bigint",
  "openssl",
  "parking_lot",
  "rand",
@@ -828,10 +829,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-traits"
-version = "0.2.15"
+name = "num-bigint"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
@@ -1197,6 +1217,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "lz4_flex",
+ "num-bigint",
  "scylla-macros",
  "snap",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bigdecimal"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d712318a27c7150326677b321a5fa91b55f6d9034ffd67f20319e147d40cee"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.65.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +255,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64",
+ "bigdecimal",
  "chrono",
  "futures",
  "hdrhistogram",
@@ -673,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.5"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "linked-hash-map"
@@ -1214,6 +1228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64037fb9d9c59ae15137fff9a56c4d528908dfd38d09e75b5f8e56e3894966dd"
 dependencies = [
  "async-trait",
+ "bigdecimal",
  "byteorder",
  "bytes",
  "lz4_flex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,11 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 rust-strictmath = "0.1.1"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_yaml = { version = "0.8", optional = true }
+uuid = { version = "1.0", optional = true }
 
 [features]
 default = ["user-profile"]
-user-profile = ["dep:serde", "dep:serde_yaml"]
+user-profile = ["dep:serde", "dep:serde_yaml", "dep:uuid"]
 
 [dev-dependencies]
 ntest = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,5 @@ user-profile = ["dep:serde", "dep:serde_yaml"]
 
 [dev-dependencies]
 ntest = "0.8"
+num-bigint = "0.4"
+scylla = { version = "0.13.0", features = ["ssl", "num-bigint-04"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,4 +45,9 @@ user-profile = ["dep:serde", "dep:serde_yaml"]
 [dev-dependencies]
 ntest = "0.8"
 num-bigint = "0.4"
-scylla = { version = "0.13.0", features = ["ssl", "num-bigint-04"] }
+bigdecimal = "0.4"
+scylla = { version = "0.13.0", features = [
+    "ssl",
+    "num-bigint-04",
+    "bigdecimal-04",
+] }

--- a/src/bin/cql-stress-cassandra-stress/java_generate/values/boolean.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/values/boolean.rs
@@ -1,0 +1,30 @@
+use scylla::frame::response::result::CqlValue;
+
+use crate::java_generate::distribution::Distribution;
+
+use super::{ValueGenerator, ValueGeneratorFactory};
+
+#[derive(Default)]
+pub struct Boolean;
+
+impl ValueGenerator for Boolean {
+    fn generate(
+        &mut self,
+        identity_distribution: &mut dyn Distribution,
+        _size_distribution: &mut dyn Distribution,
+    ) -> CqlValue {
+        // For some reason original c-s returns:
+        // identity_distribution.next_i64() % 1 == 0 which is always true.
+        //
+        // We decided not to follow c-s here and to return truly random boolean.
+        CqlValue::Boolean(identity_distribution.next_i64() % 2 == 1)
+    }
+}
+
+pub struct BooleanFactory;
+
+impl ValueGeneratorFactory for BooleanFactory {
+    fn create(&self) -> Box<dyn ValueGenerator> {
+        Box::<Boolean>::default()
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/java_generate/values/decimal.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/values/decimal.rs
@@ -1,0 +1,122 @@
+use scylla::frame::{response::result::CqlValue, value::CqlDecimal};
+
+use crate::java_generate::distribution::Distribution;
+
+use super::{ValueGenerator, ValueGeneratorFactory};
+
+#[derive(Default)]
+pub struct Decimal;
+
+impl ValueGenerator for Decimal {
+    fn generate(
+        &mut self,
+        identity_distribution: &mut dyn Distribution,
+        _size_distribution: &mut dyn Distribution,
+    ) -> CqlValue {
+        // The comment of Java's `BigDecimal::valueOf(long)` mentions:
+        // ```Translates a long value into a BigDecimal with a scale of zero.```
+        //
+        // The native representation of `decimal` consists of a `varint` value
+        // and a 32-bit scale/exponent.
+        // This means that we simply need to convert generated i64 value to
+        // `varint`'s native representation and provide a 0-scale.
+        CqlValue::Decimal(CqlDecimal::from_signed_be_bytes_slice_and_exponent(
+            &identity_distribution.next_i64().to_be_bytes(),
+            0,
+        ))
+    }
+}
+
+pub struct DecimalFactory;
+
+impl ValueGeneratorFactory for DecimalFactory {
+    fn create(&self) -> Box<dyn ValueGenerator> {
+        Box::<Decimal>::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bigdecimal::BigDecimal;
+
+    use crate::java_generate::{
+        distribution::fixed::FixedDistribution,
+        values::{decimal::Decimal, Generator, GeneratorConfig},
+    };
+
+    fn bigdecimals_from_i64(values: impl IntoIterator<Item = i64>) -> Vec<BigDecimal> {
+        values.into_iter().map(BigDecimal::from).collect()
+    }
+
+    #[test]
+    fn small_decimal_generator_test() {
+        let config = GeneratorConfig::new(
+            "randomstrC0",
+            None,
+            Some(Box::new(FixedDistribution::new(5))),
+        );
+        let inet_gen = Box::<Decimal>::default();
+        let mut gen = Generator::new(inet_gen, config, String::from("C0"));
+
+        // Values which we test against are generated from c-s.
+        gen.set_seed(0);
+        let results = (0..5)
+            .map(|_| -> BigDecimal { gen.generate().into_cql_decimal().unwrap().into() })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            bigdecimals_from_i64([
+                40527743656,
+                72758341290,
+                51163282362,
+                73862230802,
+                26689604229,
+            ]),
+            results
+        );
+
+        gen.set_seed(0xdeadcafe);
+        let results = (0..5)
+            .map(|_| -> BigDecimal { gen.generate().into_cql_decimal().unwrap().into() })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            bigdecimals_from_i64([
+                26622490754,
+                1431881157,
+                26582476501,
+                62694973673,
+                82585085279,
+            ]),
+            results
+        );
+
+        gen.set_seed(i64::MIN);
+        let results = (0..5)
+            .map(|_| -> BigDecimal { gen.generate().into_cql_decimal().unwrap().into() })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            bigdecimals_from_i64([
+                40527743656,
+                72758341290,
+                51163282362,
+                73862230802,
+                26689604229,
+            ]),
+            results
+        );
+
+        gen.set_seed(i64::MAX);
+        let results = (0..5)
+            .map(|_| -> BigDecimal { gen.generate().into_cql_decimal().unwrap().into() })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            bigdecimals_from_i64([
+                59463298171,
+                52522298470,
+                78786908585,
+                22825301439,
+                15681513599,
+            ]),
+            results
+        );
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/java_generate/values/float.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/values/float.rs
@@ -1,0 +1,201 @@
+use scylla::frame::response::result::CqlValue;
+
+use crate::java_generate::distribution::Distribution;
+
+use super::{ValueGenerator, ValueGeneratorFactory};
+
+#[derive(Default)]
+pub struct Float;
+
+impl ValueGenerator for Float {
+    fn generate(
+        &mut self,
+        identity_distribution: &mut dyn Distribution,
+        _size_distribution: &mut dyn Distribution,
+    ) -> CqlValue {
+        CqlValue::Float(identity_distribution.next_f64() as f32)
+    }
+}
+
+pub struct FloatFactory;
+
+impl ValueGeneratorFactory for FloatFactory {
+    fn create(&self) -> Box<dyn ValueGenerator> {
+        Box::<Float>::default()
+    }
+}
+
+#[derive(Default)]
+pub struct Double;
+
+impl ValueGenerator for Double {
+    fn generate(
+        &mut self,
+        identity_distribution: &mut dyn Distribution,
+        _size_distribution: &mut dyn Distribution,
+    ) -> CqlValue {
+        CqlValue::Double(identity_distribution.next_f64())
+    }
+}
+
+pub struct DoubleFactory;
+
+impl ValueGeneratorFactory for DoubleFactory {
+    fn create(&self) -> Box<dyn ValueGenerator> {
+        Box::<Double>::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::java_generate::{
+        distribution::fixed::FixedDistribution,
+        values::{Generator, GeneratorConfig},
+    };
+
+    use super::{Double, Float};
+
+    #[test]
+    fn small_float_generator_test() {
+        let config = GeneratorConfig::new(
+            "randomstrC0",
+            None,
+            Some(Box::new(FixedDistribution::new(5))),
+        );
+        let text_gen = Box::<Float>::default();
+        let mut gen = Generator::new(text_gen, config, String::from("C0"));
+
+        // Results were generated from original cassandra-stress.
+        gen.set_seed(0);
+        let results = (0..5)
+            .map(|_| gen.generate().as_float().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            vec![
+                4.0527745E10,
+                7.275834E10,
+                5.1163283E10,
+                7.3862234E10,
+                2.6689604E10,
+            ],
+            results
+        );
+
+        gen.set_seed(0xdeadcafe);
+        let results = (0..5)
+            .map(|_| gen.generate().as_float().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            vec![
+                2.662249E10,
+                1.4318812E9,
+                2.6582477E10,
+                6.2694973E10,
+                8.258508E10,
+            ],
+            results
+        );
+
+        gen.set_seed(i64::MIN);
+        let results = (0..5)
+            .map(|_| gen.generate().as_float().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            vec![
+                4.0527745E10,
+                7.275834E10,
+                5.1163283E10,
+                7.3862234E10,
+                2.6689604E10,
+            ],
+            results
+        );
+
+        gen.set_seed(i64::MAX);
+        let results = (0..5)
+            .map(|_| gen.generate().as_float().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            vec![
+                5.94633E10,
+                5.25223E10,
+                7.878691E10,
+                2.2825302E10,
+                1.5681513E10,
+            ],
+            results
+        );
+    }
+
+    #[test]
+    fn small_double_generator_test() {
+        let config = GeneratorConfig::new(
+            "randomstrC0",
+            None,
+            Some(Box::new(FixedDistribution::new(5))),
+        );
+        let text_gen = Box::<Double>::default();
+        let mut gen = Generator::new(text_gen, config, String::from("C0"));
+
+        // Results were generated from original cassandra-stress.
+        gen.set_seed(0);
+        let results = (0..5)
+            .map(|_| gen.generate().as_double().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            vec![
+                4.052774365638973E10,
+                7.275834129052333E10,
+                5.116328236284534E10,
+                7.38622308026015E10,
+                2.6689604229831688E10,
+            ],
+            results
+        );
+
+        gen.set_seed(0xdeadcafe);
+        let results = (0..5)
+            .map(|_| gen.generate().as_double().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            vec![
+                2.6622490754583496E10,
+                1.431881157104631E9,
+                2.6582476501090935E10,
+                6.26949736733251E10,
+                8.258508527927824E10,
+            ],
+            results
+        );
+
+        gen.set_seed(i64::MIN);
+        let results = (0..5)
+            .map(|_| gen.generate().as_double().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            vec![
+                4.052774365638973E10,
+                7.275834129052333E10,
+                5.116328236284534E10,
+                7.38622308026015E10,
+                2.6689604229831688E10,
+            ],
+            results
+        );
+
+        gen.set_seed(i64::MAX);
+        let results = (0..5)
+            .map(|_| gen.generate().as_double().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            vec![
+                5.946329817132646E10,
+                5.2522298470748795E10,
+                7.878690858538501E10,
+                2.2825301439990566E10,
+                1.5681513599571617E10,
+            ],
+            results
+        );
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/java_generate/values/inet.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/values/inet.rs
@@ -1,0 +1,122 @@
+use std::net::{IpAddr, Ipv4Addr};
+
+use scylla::frame::response::result::CqlValue;
+
+use crate::java_generate::distribution::Distribution;
+
+use super::{ValueGenerator, ValueGeneratorFactory};
+
+#[derive(Default)]
+pub struct Inet;
+
+impl ValueGenerator for Inet {
+    fn generate(
+        &mut self,
+        identity_distribution: &mut dyn Distribution,
+        _size_distribution: &mut dyn Distribution,
+    ) -> CqlValue {
+        let octets = (identity_distribution.next_i64() as i32).to_be_bytes();
+        CqlValue::Inet(IpAddr::V4(Ipv4Addr::from(octets)))
+    }
+}
+
+pub struct InetFactory;
+
+impl ValueGeneratorFactory for InetFactory {
+    fn create(&self) -> Box<dyn ValueGenerator> {
+        Box::<Inet>::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        net::{IpAddr, Ipv4Addr},
+        str::FromStr,
+    };
+
+    use crate::java_generate::{
+        distribution::fixed::FixedDistribution,
+        values::{Generator, GeneratorConfig},
+    };
+
+    use super::Inet;
+
+    fn ipv4_from_string(ips: impl IntoIterator<Item = &'static str>) -> Vec<IpAddr> {
+        ips.into_iter()
+            .map(|ip| IpAddr::V4(Ipv4Addr::from_str(ip).unwrap()))
+            .collect()
+    }
+
+    #[test]
+    fn small_inet_generator_test() {
+        let config = GeneratorConfig::new(
+            "randomstrC0",
+            None,
+            Some(Box::new(FixedDistribution::new(5))),
+        );
+        let inet_gen = Box::<Inet>::default();
+        let mut gen = Generator::new(inet_gen, config, String::from("C0"));
+
+        // Values which we test against are generated from c-s.
+        gen.set_seed(0);
+        let results = (0..5)
+            .map(|_| gen.generate().as_inet().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            ipv4_from_string([
+                "111.164.74.168",
+                "240.188.46.170",
+                "233.145.187.186",
+                "50.136.51.18",
+                "54.211.10.133"
+            ]),
+            results
+        );
+
+        gen.set_seed(0xdeadcafe);
+        let results = (0..5)
+            .map(|_| gen.generate().as_inet().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            ipv4_from_string([
+                "50.210.248.130",
+                "85.88.197.197",
+                "48.112.102.213",
+                "152.233.96.233",
+                "58.116.101.95"
+            ]),
+            results
+        );
+
+        gen.set_seed(i64::MIN);
+        let results = (0..5)
+            .map(|_| gen.generate().as_inet().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            ipv4_from_string([
+                "111.164.74.168",
+                "240.188.46.170",
+                "233.145.187.186",
+                "50.136.51.18",
+                "54.211.10.133"
+            ]),
+            results
+        );
+
+        gen.set_seed(i64::MAX);
+        let results = (0..5)
+            .map(|_| gen.generate().as_inet().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            ipv4_from_string([
+                "216.73.236.123",
+                "58.146.172.102",
+                "88.16.209.169",
+                "80.126.117.191",
+                "166.176.232.127"
+            ]),
+            results
+        );
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/java_generate/values/int.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/values/int.rs
@@ -1,0 +1,36 @@
+use scylla::frame::response::result::CqlValue;
+
+use crate::java_generate::distribution::Distribution;
+
+use super::ValueGenerator;
+use super::ValueGeneratorFactory;
+
+macro_rules! impl_value_generator_for_fixed_integer {
+    ($cql_type:tt, $cql_type_factory:tt, $rust_type:ty) => {
+        #[derive(Default)]
+        pub struct $cql_type;
+
+        impl ValueGenerator for $cql_type {
+            fn generate(
+                &mut self,
+                identity_distribution: &mut dyn Distribution,
+                _size_distribution: &mut dyn Distribution,
+            ) -> CqlValue {
+                CqlValue::$cql_type(identity_distribution.next_i64() as $rust_type)
+            }
+        }
+
+        pub struct $cql_type_factory;
+
+        impl ValueGeneratorFactory for $cql_type_factory {
+            fn create(&self) -> Box<dyn ValueGenerator> {
+                Box::new($cql_type)
+            }
+        }
+    };
+}
+
+impl_value_generator_for_fixed_integer!(BigInt, BigIntFactory, i64);
+impl_value_generator_for_fixed_integer!(Int, IntFactory, i32);
+impl_value_generator_for_fixed_integer!(SmallInt, SmallIntFactory, i16);
+impl_value_generator_for_fixed_integer!(TinyInt, TinyIntFactory, i8);

--- a/src/bin/cql-stress-cassandra-stress/java_generate/values/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/values/mod.rs
@@ -15,6 +15,8 @@ pub mod hex_blob;
 #[cfg(feature = "user-profile")]
 pub mod boolean;
 #[cfg(feature = "user-profile")]
+pub mod float;
+#[cfg(feature = "user-profile")]
 pub mod int;
 #[cfg(feature = "user-profile")]
 pub mod text;
@@ -62,6 +64,7 @@ impl Generator {
     ) -> Result<Box<dyn ValueGeneratorFactory>> {
         use self::blob::BlobFactory;
         use boolean::BooleanFactory;
+        use float::{DoubleFactory, FloatFactory};
         use int::{BigIntFactory, IntFactory, SmallIntFactory, TinyIntFactory};
         use text::TextFactory;
 
@@ -74,6 +77,8 @@ impl Generator {
                 scylla::transport::topology::NativeType::SmallInt => Ok(Box::new(SmallIntFactory)),
                 scylla::transport::topology::NativeType::TinyInt => Ok(Box::new(TinyIntFactory)),
                 scylla::transport::topology::NativeType::Boolean => Ok(Box::new(BooleanFactory)),
+                scylla::transport::topology::NativeType::Float => Ok(Box::new(FloatFactory)),
+                scylla::transport::topology::NativeType::Double => Ok(Box::new(DoubleFactory)),
                 _ => anyhow::bail!(
                     "Column type {:?} is not yet supported by the tool!",
                     native_type

--- a/src/bin/cql-stress-cassandra-stress/java_generate/values/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/values/mod.rs
@@ -25,6 +25,8 @@ pub mod int;
 #[cfg(feature = "user-profile")]
 pub mod text;
 #[cfg(feature = "user-profile")]
+pub mod uuid;
+#[cfg(feature = "user-profile")]
 pub mod varint;
 
 pub use blob::Blob;
@@ -75,6 +77,7 @@ impl Generator {
         use inet::InetFactory;
         use int::{BigIntFactory, IntFactory, SmallIntFactory, TinyIntFactory};
         use text::TextFactory;
+        use uuid::UuidFactory;
         use varint::VarIntFactory;
 
         match typ {
@@ -91,6 +94,7 @@ impl Generator {
                 scylla::transport::topology::NativeType::Inet => Ok(Box::new(InetFactory)),
                 scylla::transport::topology::NativeType::Varint => Ok(Box::new(VarIntFactory)),
                 scylla::transport::topology::NativeType::Decimal => Ok(Box::new(DecimalFactory)),
+                scylla::transport::topology::NativeType::Uuid => Ok(Box::new(UuidFactory)),
                 _ => anyhow::bail!(
                     "Column type {:?} is not yet supported by the tool!",
                     native_type

--- a/src/bin/cql-stress-cassandra-stress/java_generate/values/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/values/mod.rs
@@ -15,6 +15,8 @@ pub mod hex_blob;
 #[cfg(feature = "user-profile")]
 pub mod boolean;
 #[cfg(feature = "user-profile")]
+pub mod decimal;
+#[cfg(feature = "user-profile")]
 pub mod float;
 #[cfg(feature = "user-profile")]
 pub mod inet;
@@ -68,6 +70,7 @@ impl Generator {
     ) -> Result<Box<dyn ValueGeneratorFactory>> {
         use self::blob::BlobFactory;
         use boolean::BooleanFactory;
+        use decimal::DecimalFactory;
         use float::{DoubleFactory, FloatFactory};
         use inet::InetFactory;
         use int::{BigIntFactory, IntFactory, SmallIntFactory, TinyIntFactory};
@@ -87,6 +90,7 @@ impl Generator {
                 scylla::transport::topology::NativeType::Double => Ok(Box::new(DoubleFactory)),
                 scylla::transport::topology::NativeType::Inet => Ok(Box::new(InetFactory)),
                 scylla::transport::topology::NativeType::Varint => Ok(Box::new(VarIntFactory)),
+                scylla::transport::topology::NativeType::Decimal => Ok(Box::new(DecimalFactory)),
                 _ => anyhow::bail!(
                     "Column type {:?} is not yet supported by the tool!",
                     native_type

--- a/src/bin/cql-stress-cassandra-stress/java_generate/values/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/values/mod.rs
@@ -12,6 +12,9 @@ use anyhow::Result;
 pub mod blob;
 pub mod hex_blob;
 
+#[cfg(feature = "user-profile")]
+pub mod text;
+
 pub use blob::Blob;
 pub use hex_blob::HexBlob;
 
@@ -54,10 +57,12 @@ impl Generator {
         typ: &CqlType,
     ) -> Result<Box<dyn ValueGeneratorFactory>> {
         use self::blob::BlobFactory;
+        use text::TextFactory;
 
         match typ {
             CqlType::Native(native_type) => match native_type {
                 scylla::transport::topology::NativeType::Blob => Ok(Box::new(BlobFactory)),
+                scylla::transport::topology::NativeType::Text => Ok(Box::new(TextFactory)),
                 _ => anyhow::bail!(
                     "Column type {:?} is not yet supported by the tool!",
                     native_type

--- a/src/bin/cql-stress-cassandra-stress/java_generate/values/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/values/mod.rs
@@ -22,6 +22,8 @@ pub mod inet;
 pub mod int;
 #[cfg(feature = "user-profile")]
 pub mod text;
+#[cfg(feature = "user-profile")]
+pub mod varint;
 
 pub use blob::Blob;
 pub use hex_blob::HexBlob;
@@ -70,6 +72,7 @@ impl Generator {
         use inet::InetFactory;
         use int::{BigIntFactory, IntFactory, SmallIntFactory, TinyIntFactory};
         use text::TextFactory;
+        use varint::VarIntFactory;
 
         match typ {
             CqlType::Native(native_type) => match native_type {
@@ -83,6 +86,7 @@ impl Generator {
                 scylla::transport::topology::NativeType::Float => Ok(Box::new(FloatFactory)),
                 scylla::transport::topology::NativeType::Double => Ok(Box::new(DoubleFactory)),
                 scylla::transport::topology::NativeType::Inet => Ok(Box::new(InetFactory)),
+                scylla::transport::topology::NativeType::Varint => Ok(Box::new(VarIntFactory)),
                 _ => anyhow::bail!(
                     "Column type {:?} is not yet supported by the tool!",
                     native_type

--- a/src/bin/cql-stress-cassandra-stress/java_generate/values/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/values/mod.rs
@@ -17,6 +17,8 @@ pub mod boolean;
 #[cfg(feature = "user-profile")]
 pub mod float;
 #[cfg(feature = "user-profile")]
+pub mod inet;
+#[cfg(feature = "user-profile")]
 pub mod int;
 #[cfg(feature = "user-profile")]
 pub mod text;
@@ -65,6 +67,7 @@ impl Generator {
         use self::blob::BlobFactory;
         use boolean::BooleanFactory;
         use float::{DoubleFactory, FloatFactory};
+        use inet::InetFactory;
         use int::{BigIntFactory, IntFactory, SmallIntFactory, TinyIntFactory};
         use text::TextFactory;
 
@@ -79,6 +82,7 @@ impl Generator {
                 scylla::transport::topology::NativeType::Boolean => Ok(Box::new(BooleanFactory)),
                 scylla::transport::topology::NativeType::Float => Ok(Box::new(FloatFactory)),
                 scylla::transport::topology::NativeType::Double => Ok(Box::new(DoubleFactory)),
+                scylla::transport::topology::NativeType::Inet => Ok(Box::new(InetFactory)),
                 _ => anyhow::bail!(
                     "Column type {:?} is not yet supported by the tool!",
                     native_type

--- a/src/bin/cql-stress-cassandra-stress/java_generate/values/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/values/mod.rs
@@ -13,6 +13,8 @@ pub mod blob;
 pub mod hex_blob;
 
 #[cfg(feature = "user-profile")]
+pub mod int;
+#[cfg(feature = "user-profile")]
 pub mod text;
 
 pub use blob::Blob;
@@ -57,12 +59,17 @@ impl Generator {
         typ: &CqlType,
     ) -> Result<Box<dyn ValueGeneratorFactory>> {
         use self::blob::BlobFactory;
+        use int::{BigIntFactory, IntFactory, SmallIntFactory, TinyIntFactory};
         use text::TextFactory;
 
         match typ {
             CqlType::Native(native_type) => match native_type {
                 scylla::transport::topology::NativeType::Blob => Ok(Box::new(BlobFactory)),
                 scylla::transport::topology::NativeType::Text => Ok(Box::new(TextFactory)),
+                scylla::transport::topology::NativeType::BigInt => Ok(Box::new(BigIntFactory)),
+                scylla::transport::topology::NativeType::Int => Ok(Box::new(IntFactory)),
+                scylla::transport::topology::NativeType::SmallInt => Ok(Box::new(SmallIntFactory)),
+                scylla::transport::topology::NativeType::TinyInt => Ok(Box::new(TinyIntFactory)),
                 _ => anyhow::bail!(
                     "Column type {:?} is not yet supported by the tool!",
                     native_type

--- a/src/bin/cql-stress-cassandra-stress/java_generate/values/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/values/mod.rs
@@ -13,6 +13,8 @@ pub mod blob;
 pub mod hex_blob;
 
 #[cfg(feature = "user-profile")]
+pub mod boolean;
+#[cfg(feature = "user-profile")]
 pub mod int;
 #[cfg(feature = "user-profile")]
 pub mod text;
@@ -59,6 +61,7 @@ impl Generator {
         typ: &CqlType,
     ) -> Result<Box<dyn ValueGeneratorFactory>> {
         use self::blob::BlobFactory;
+        use boolean::BooleanFactory;
         use int::{BigIntFactory, IntFactory, SmallIntFactory, TinyIntFactory};
         use text::TextFactory;
 
@@ -70,6 +73,7 @@ impl Generator {
                 scylla::transport::topology::NativeType::Int => Ok(Box::new(IntFactory)),
                 scylla::transport::topology::NativeType::SmallInt => Ok(Box::new(SmallIntFactory)),
                 scylla::transport::topology::NativeType::TinyInt => Ok(Box::new(TinyIntFactory)),
+                scylla::transport::topology::NativeType::Boolean => Ok(Box::new(BooleanFactory)),
                 _ => anyhow::bail!(
                     "Column type {:?} is not yet supported by the tool!",
                     native_type

--- a/src/bin/cql-stress-cassandra-stress/java_generate/values/text.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/values/text.rs
@@ -1,0 +1,134 @@
+use std::cmp::min;
+
+use scylla::frame::response::result::CqlValue;
+
+use crate::java_generate::{distribution::Distribution, faster_random::FasterRandom};
+
+use super::{ValueGenerator, ValueGeneratorFactory};
+
+/// Text generator based on c-s Strings generator.
+/// See https://github.com/scylladb/scylla-tools-java/blob/master/tools/stress/src/org/apache/cassandra/stress/generate/values/Strings.java
+#[derive(Default)]
+pub struct Text {
+    rng: FasterRandom,
+}
+
+impl ValueGenerator for Text {
+    fn generate(
+        &mut self,
+        identity_distribution: &mut dyn Distribution,
+        size_distribution: &mut dyn Distribution,
+    ) -> CqlValue {
+        let seed = identity_distribution.next_i64();
+        size_distribution.set_seed(seed);
+        self.rng.set_seed(!seed);
+        let size = size_distribution.next_i64() as usize;
+
+        let mut result = Vec::with_capacity(size);
+        let mut i = 0;
+
+        while i < size {
+            let v = self
+                .rng
+                .next_i64()
+                .to_le_bytes()
+                .map(|byte| ((byte & 127) + 32) & 127);
+
+            let n = min(size - i, v.len());
+            result.extend_from_slice(&v[0..n]);
+            i += n;
+        }
+
+        CqlValue::Text(String::from_utf8(result).expect("Invalid utf-8 text generated."))
+    }
+}
+
+pub struct TextFactory;
+
+impl ValueGeneratorFactory for TextFactory {
+    fn create(&self) -> Box<dyn ValueGenerator> {
+        Box::<Text>::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::java_generate::{
+        distribution::fixed::FixedDistribution,
+        values::{Generator, GeneratorConfig},
+    };
+
+    use super::Text;
+
+    #[test]
+    fn small_text_generator_test() {
+        let config = GeneratorConfig::new(
+            "randomstrC0",
+            None,
+            Some(Box::new(FixedDistribution::new(5))),
+        );
+        let text_gen = Box::<Text>::default();
+        let mut gen = Generator::new(text_gen, config, String::from("C0"));
+
+        // Results were generated from original cassandra-stress.
+        gen.set_seed(0);
+        let results = (0..5)
+            .map(|_| gen.generate().into_string().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            vec![
+                "I\t\u{0011}J-",
+                "\\czv[",
+                "zN\u{0008}34",
+                "EWVyW",
+                "z\u{0002}i$}",
+            ],
+            results
+        );
+
+        gen.set_seed(0xdeadcafe);
+        let results = (0..5)
+            .map(|_| gen.generate().into_string().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            vec![
+                "vFtqJ",
+                "Q\u{001E}\u{0006}\u{0019}6",
+                "o\u{0001}u\u{0007}f",
+                "\u{0013}Z+M8",
+                "y\u{001F}q~\u{001A}",
+            ],
+            results
+        );
+
+        gen.set_seed(i64::MIN);
+        let results = (0..5)
+            .map(|_| gen.generate().into_string().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            vec![
+                "I\t\u{0011}J-",
+                "\\czv[",
+                "zN\u{0008}34",
+                "EWVyW",
+                "z\u{0002}i$}",
+            ],
+            results
+        );
+
+        gen.set_seed(i64::MAX);
+        let results = (0..5)
+            .map(|_| gen.generate().into_string().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            vec![
+                "\u{0008}Z&\u{0018}\u{001B}",
+                "\u{001D}\u{0018}ua_",
+                "$wYR\u{0008}",
+                "\u{001B}2\u{0019}\u{0013}\u{001A}",
+                ":\u{001F}5Q\u{001B}",
+            ],
+            results
+        );
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/java_generate/values/uuid.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/values/uuid.rs
@@ -1,0 +1,116 @@
+use scylla::frame::response::result::CqlValue;
+
+use crate::java_generate::distribution::Distribution;
+
+use super::{ValueGenerator, ValueGeneratorFactory};
+
+#[derive(Default)]
+pub struct Uuid;
+
+impl ValueGenerator for Uuid {
+    fn generate(
+        &mut self,
+        identity_distribution: &mut dyn Distribution,
+        _size_distribution: &mut dyn Distribution,
+    ) -> CqlValue {
+        let v = identity_distribution.next_i64();
+        CqlValue::Uuid(uuid::Uuid::from_u64_pair(v as u64, v as u64))
+    }
+}
+
+pub struct UuidFactory;
+
+impl ValueGeneratorFactory for UuidFactory {
+    fn create(&self) -> Box<dyn ValueGenerator> {
+        Box::<Uuid>::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use crate::java_generate::{
+        distribution::fixed::FixedDistribution,
+        values::{uuid::Uuid, Generator, GeneratorConfig},
+    };
+
+    fn uuids_from_str(values: impl IntoIterator<Item = &'static str>) -> Vec<uuid::Uuid> {
+        values
+            .into_iter()
+            .map(|v| uuid::Uuid::from_str(v).unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn small_uuid_generator_test() {
+        let config = GeneratorConfig::new(
+            "randomstrC0",
+            None,
+            Some(Box::new(FixedDistribution::new(5))),
+        );
+        let inet_gen = Box::<Uuid>::default();
+        let mut gen = Generator::new(inet_gen, config, String::from("C0"));
+
+        // Values which we test against are generated from c-s.
+        gen.set_seed(0);
+        let results = (0..5)
+            .map(|_| gen.generate().as_uuid().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            uuids_from_str([
+                "00000009-6fa4-4aa8-0000-00096fa44aa8",
+                "00000010-f0bc-2eaa-0000-0010f0bc2eaa",
+                "0000000b-e991-bbba-0000-000be991bbba",
+                "00000011-3288-3312-0000-001132883312",
+                "00000006-36d3-0a85-0000-000636d30a85"
+            ]),
+            results
+        );
+
+        gen.set_seed(0xdeadcafe);
+        let results = (0..5)
+            .map(|_| gen.generate().as_uuid().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            uuids_from_str([
+                "00000006-32d2-f882-0000-000632d2f882",
+                "00000000-5558-c5c5-0000-00005558c5c5",
+                "00000006-3070-66d5-0000-0006307066d5",
+                "0000000e-98e9-60e9-0000-000e98e960e9",
+                "00000013-3a74-655f-0000-00133a74655f",
+            ]),
+            results
+        );
+
+        gen.set_seed(i64::MIN);
+        let results = (0..5)
+            .map(|_| gen.generate().as_uuid().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            uuids_from_str([
+                "00000009-6fa4-4aa8-0000-00096fa44aa8",
+                "00000010-f0bc-2eaa-0000-0010f0bc2eaa",
+                "0000000b-e991-bbba-0000-000be991bbba",
+                "00000011-3288-3312-0000-001132883312",
+                "00000006-36d3-0a85-0000-000636d30a85",
+            ]),
+            results
+        );
+
+        gen.set_seed(i64::MAX);
+        let results = (0..5)
+            .map(|_| gen.generate().as_uuid().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            uuids_from_str([
+                "0000000d-d849-ec7b-0000-000dd849ec7b",
+                "0000000c-3a92-ac66-0000-000c3a92ac66",
+                "00000012-5810-d1a9-0000-00125810d1a9",
+                "00000005-507e-75bf-0000-0005507e75bf",
+                "00000003-a6b0-e87f-0000-0003a6b0e87f",
+            ]),
+            results
+        );
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/java_generate/values/varint.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/values/varint.rs
@@ -1,0 +1,116 @@
+use scylla::frame::{response::result::CqlValue, value::CqlVarint};
+
+use crate::java_generate::distribution::Distribution;
+
+use super::{ValueGenerator, ValueGeneratorFactory};
+
+#[derive(Default)]
+pub struct VarInt;
+
+impl ValueGenerator for VarInt {
+    fn generate(
+        &mut self,
+        identity_distribution: &mut dyn Distribution,
+        _size_distribution: &mut dyn Distribution,
+    ) -> CqlValue {
+        // The native representation of `varint` is a signed representation
+        // in big-endian order.
+        CqlValue::Varint(CqlVarint::from_signed_bytes_be_slice(
+            &identity_distribution.next_i64().to_be_bytes(),
+        ))
+    }
+}
+
+pub struct VarIntFactory;
+
+impl ValueGeneratorFactory for VarIntFactory {
+    fn create(&self) -> Box<dyn ValueGenerator> {
+        Box::<VarInt>::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use num_bigint::BigInt;
+
+    use crate::java_generate::{
+        distribution::fixed::FixedDistribution,
+        values::{varint::VarInt, Generator, GeneratorConfig},
+    };
+
+    fn num_bigints_from_i64(values: impl IntoIterator<Item = i64>) -> Vec<BigInt> {
+        values.into_iter().map(BigInt::from).collect()
+    }
+
+    #[test]
+    fn small_varint_generator_test() {
+        let config = GeneratorConfig::new(
+            "randomstrC0",
+            None,
+            Some(Box::new(FixedDistribution::new(5))),
+        );
+        let inet_gen = Box::<VarInt>::default();
+        let mut gen = Generator::new(inet_gen, config, String::from("C0"));
+
+        // Values which we test against are generated from c-s.
+        gen.set_seed(0);
+        let results = (0..5)
+            .map(|_| -> BigInt { gen.generate().into_cql_varint().unwrap().into() })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            num_bigints_from_i64([
+                40527743656,
+                72758341290,
+                51163282362,
+                73862230802,
+                26689604229,
+            ]),
+            results
+        );
+
+        gen.set_seed(0xdeadcafe);
+        let results = (0..5)
+            .map(|_| -> BigInt { gen.generate().into_cql_varint().unwrap().into() })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            num_bigints_from_i64([
+                26622490754,
+                1431881157,
+                26582476501,
+                62694973673,
+                82585085279,
+            ]),
+            results
+        );
+
+        gen.set_seed(i64::MIN);
+        let results = (0..5)
+            .map(|_| -> BigInt { gen.generate().into_cql_varint().unwrap().into() })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            num_bigints_from_i64([
+                40527743656,
+                72758341290,
+                51163282362,
+                73862230802,
+                26689604229,
+            ]),
+            results
+        );
+
+        gen.set_seed(i64::MAX);
+        let results = (0..5)
+            .map(|_| -> BigInt { gen.generate().into_cql_varint().unwrap().into() })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            num_bigints_from_i64([
+                59463298171,
+                52522298470,
+                78786908585,
+                22825301439,
+                15681513599,
+            ]),
+            results
+        );
+    }
+}

--- a/tools/cassandra_stress_ci.py
+++ b/tools/cassandra_stress_ci.py
@@ -110,3 +110,9 @@ def test_user_varint_type(default_runtime_args, scylla_docker_node,
                           cassandra_stress, cql_stress):
     run_user(runtime_args=default_runtime_args, type_name="varint",
              node=scylla_docker_node, cs=cassandra_stress, cql_stress=cql_stress)
+
+
+def test_user_decimal_type(default_runtime_args, scylla_docker_node,
+                           cassandra_stress, cql_stress):
+    run_user(runtime_args=default_runtime_args, type_name="decimal",
+             node=scylla_docker_node, cs=cassandra_stress, cql_stress=cql_stress)

--- a/tools/cassandra_stress_ci.py
+++ b/tools/cassandra_stress_ci.py
@@ -98,3 +98,9 @@ def test_user_double_type(default_runtime_args, scylla_docker_node,
                           cassandra_stress, cql_stress):
     run_user(runtime_args=default_runtime_args, type_name="double",
              node=scylla_docker_node, cs=cassandra_stress, cql_stress=cql_stress)
+
+
+def test_user_inet_type(default_runtime_args, scylla_docker_node,
+                        cassandra_stress, cql_stress):
+    run_user(runtime_args=default_runtime_args, type_name="inet",
+             node=scylla_docker_node, cs=cassandra_stress, cql_stress=cql_stress)

--- a/tools/cassandra_stress_ci.py
+++ b/tools/cassandra_stress_ci.py
@@ -58,3 +58,27 @@ def test_user_text_type(default_runtime_args, scylla_docker_node,
                         cassandra_stress, cql_stress):
     run_user(runtime_args=default_runtime_args, type_name="text",
              node=scylla_docker_node, cs=cassandra_stress, cql_stress=cql_stress)
+
+
+def test_user_tinyint_type(default_runtime_args, scylla_docker_node,
+                           cassandra_stress, cql_stress):
+    run_user(runtime_args=default_runtime_args, type_name="tinyint",
+             node=scylla_docker_node, cs=cassandra_stress, cql_stress=cql_stress)
+
+
+def test_user_smallint_type(default_runtime_args, scylla_docker_node,
+                            cassandra_stress, cql_stress):
+    run_user(runtime_args=default_runtime_args, type_name="smallint",
+             node=scylla_docker_node, cs=cassandra_stress, cql_stress=cql_stress)
+
+
+def test_user_int_type(default_runtime_args, scylla_docker_node,
+                       cassandra_stress, cql_stress):
+    run_user(runtime_args=default_runtime_args, type_name="int",
+             node=scylla_docker_node, cs=cassandra_stress, cql_stress=cql_stress)
+
+
+def test_user_bigint_type(default_runtime_args, scylla_docker_node,
+                          cassandra_stress, cql_stress):
+    run_user(runtime_args=default_runtime_args, type_name="bigint",
+             node=scylla_docker_node, cs=cassandra_stress, cql_stress=cql_stress)

--- a/tools/cassandra_stress_ci.py
+++ b/tools/cassandra_stress_ci.py
@@ -104,3 +104,9 @@ def test_user_inet_type(default_runtime_args, scylla_docker_node,
                         cassandra_stress, cql_stress):
     run_user(runtime_args=default_runtime_args, type_name="inet",
              node=scylla_docker_node, cs=cassandra_stress, cql_stress=cql_stress)
+
+
+def test_user_varint_type(default_runtime_args, scylla_docker_node,
+                          cassandra_stress, cql_stress):
+    run_user(runtime_args=default_runtime_args, type_name="varint",
+             node=scylla_docker_node, cs=cassandra_stress, cql_stress=cql_stress)

--- a/tools/cassandra_stress_ci.py
+++ b/tools/cassandra_stress_ci.py
@@ -52,3 +52,9 @@ def test_user_blob_type(default_runtime_args, scylla_docker_node,
                         cassandra_stress, cql_stress):
     run_user(runtime_args=default_runtime_args, type_name="blob",
              node=scylla_docker_node, cs=cassandra_stress, cql_stress=cql_stress)
+
+
+def test_user_text_type(default_runtime_args, scylla_docker_node,
+                        cassandra_stress, cql_stress):
+    run_user(runtime_args=default_runtime_args, type_name="text",
+             node=scylla_docker_node, cs=cassandra_stress, cql_stress=cql_stress)

--- a/tools/cassandra_stress_ci.py
+++ b/tools/cassandra_stress_ci.py
@@ -116,3 +116,9 @@ def test_user_decimal_type(default_runtime_args, scylla_docker_node,
                            cassandra_stress, cql_stress):
     run_user(runtime_args=default_runtime_args, type_name="decimal",
              node=scylla_docker_node, cs=cassandra_stress, cql_stress=cql_stress)
+
+
+def test_user_uuid_type(default_runtime_args, scylla_docker_node,
+                        cassandra_stress, cql_stress):
+    run_user(runtime_args=default_runtime_args, type_name="uuid",
+             node=scylla_docker_node, cs=cassandra_stress, cql_stress=cql_stress)

--- a/tools/cassandra_stress_ci.py
+++ b/tools/cassandra_stress_ci.py
@@ -86,3 +86,15 @@ def test_user_bigint_type(default_runtime_args, scylla_docker_node,
 
 # Test for booleans is missing, since we are not compatible with original c-s.
 # C-s has a bug and always generates `true` value.
+
+
+def test_user_float_type(default_runtime_args, scylla_docker_node,
+                         cassandra_stress, cql_stress):
+    run_user(runtime_args=default_runtime_args, type_name="float",
+             node=scylla_docker_node, cs=cassandra_stress, cql_stress=cql_stress)
+
+
+def test_user_double_type(default_runtime_args, scylla_docker_node,
+                          cassandra_stress, cql_stress):
+    run_user(runtime_args=default_runtime_args, type_name="double",
+             node=scylla_docker_node, cs=cassandra_stress, cql_stress=cql_stress)

--- a/tools/cassandra_stress_ci.py
+++ b/tools/cassandra_stress_ci.py
@@ -82,3 +82,7 @@ def test_user_bigint_type(default_runtime_args, scylla_docker_node,
                           cassandra_stress, cql_stress):
     run_user(runtime_args=default_runtime_args, type_name="bigint",
              node=scylla_docker_node, cs=cassandra_stress, cql_stress=cql_stress)
+
+
+# Test for booleans is missing, since we are not compatible with original c-s.
+# C-s has a bug and always generates `true` value.

--- a/tools/util/profiles/cqlstress_bigint_profile.yaml
+++ b/tools/util/profiles/cqlstress_bigint_profile.yaml
@@ -1,0 +1,19 @@
+table: test_table
+
+table_definition: |
+  CREATE TABLE IF NOT EXISTS test_table (
+    pkey blob PRIMARY KEY,
+    c1 bigint,
+    c2 bigint,
+    c3 bigint
+   );
+
+keyspace: cqlstress_bigint_keyspace
+
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS cqlstress_bigint_keyspace 
+  WITH replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
+
+queries:
+  test_query:
+    cql: INSERT INTO cqlstress_bigint_keyspace.test_table (pkey, c1, c2, c3) VALUES (?, ?, ?, ?)

--- a/tools/util/profiles/cqlstress_blob_profile.yaml
+++ b/tools/util/profiles/cqlstress_blob_profile.yaml
@@ -12,7 +12,7 @@ keyspace: cqlstress_blob_keyspace
 
 keyspace_definition: |
   CREATE KEYSPACE IF NOT EXISTS cqlstress_blob_keyspace 
-  WITH replication = { 'class': 'SimpleStrategy', 'replication_factor': 1};
+  WITH replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
 
 queries:
   test_query:

--- a/tools/util/profiles/cqlstress_decimal_profile.yaml
+++ b/tools/util/profiles/cqlstress_decimal_profile.yaml
@@ -1,0 +1,19 @@
+table: test_table
+
+table_definition: |
+  CREATE TABLE IF NOT EXISTS test_table (
+    pkey blob PRIMARY KEY,
+    c1 decimal,
+    c2 decimal,
+    c3 decimal
+   );
+
+keyspace: cqlstress_decimal_keyspace
+
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS cqlstress_decimal_keyspace 
+  WITH replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
+
+queries:
+  test_query:
+    cql: INSERT INTO cqlstress_decimal_keyspace.test_table (pkey, c1, c2, c3) VALUES (?, ?, ?, ?)

--- a/tools/util/profiles/cqlstress_double_profile.yaml
+++ b/tools/util/profiles/cqlstress_double_profile.yaml
@@ -1,0 +1,19 @@
+table: test_table
+
+table_definition: |
+  CREATE TABLE IF NOT EXISTS test_table (
+    pkey blob PRIMARY KEY,
+    c1 double,
+    c2 double,
+    c3 double
+   );
+
+keyspace: cqlstress_double_keyspace
+
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS cqlstress_double_keyspace 
+  WITH replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
+
+queries:
+  test_query:
+    cql: INSERT INTO cqlstress_double_keyspace.test_table (pkey, c1, c2, c3) VALUES (?, ?, ?, ?)

--- a/tools/util/profiles/cqlstress_float_profile.yaml
+++ b/tools/util/profiles/cqlstress_float_profile.yaml
@@ -1,0 +1,19 @@
+table: test_table
+
+table_definition: |
+  CREATE TABLE IF NOT EXISTS test_table (
+    pkey blob PRIMARY KEY,
+    c1 float,
+    c2 float,
+    c3 float
+   );
+
+keyspace: cqlstress_float_keyspace
+
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS cqlstress_float_keyspace 
+  WITH replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
+
+queries:
+  test_query:
+    cql: INSERT INTO cqlstress_float_keyspace.test_table (pkey, c1, c2, c3) VALUES (?, ?, ?, ?)

--- a/tools/util/profiles/cqlstress_inet_profile.yaml
+++ b/tools/util/profiles/cqlstress_inet_profile.yaml
@@ -1,0 +1,19 @@
+table: test_table
+
+table_definition: |
+  CREATE TABLE IF NOT EXISTS test_table (
+    pkey blob PRIMARY KEY,
+    c1 inet,
+    c2 inet,
+    c3 inet
+   );
+
+keyspace: cqlstress_inet_keyspace
+
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS cqlstress_inet_keyspace 
+  WITH replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
+
+queries:
+  test_query:
+    cql: INSERT INTO cqlstress_inet_keyspace.test_table (pkey, c1, c2, c3) VALUES (?, ?, ?, ?)

--- a/tools/util/profiles/cqlstress_int_profile.yaml
+++ b/tools/util/profiles/cqlstress_int_profile.yaml
@@ -1,0 +1,19 @@
+table: test_table
+
+table_definition: |
+  CREATE TABLE IF NOT EXISTS test_table (
+    pkey blob PRIMARY KEY,
+    c1 int,
+    c2 int,
+    c3 int
+   );
+
+keyspace: cqlstress_int_keyspace
+
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS cqlstress_int_keyspace 
+  WITH replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
+
+queries:
+  test_query:
+    cql: INSERT INTO cqlstress_int_keyspace.test_table (pkey, c1, c2, c3) VALUES (?, ?, ?, ?)

--- a/tools/util/profiles/cqlstress_smallint_profile.yaml
+++ b/tools/util/profiles/cqlstress_smallint_profile.yaml
@@ -1,0 +1,19 @@
+table: test_table
+
+table_definition: |
+  CREATE TABLE IF NOT EXISTS test_table (
+    pkey blob PRIMARY KEY,
+    c1 smallint,
+    c2 smallint,
+    c3 smallint
+   );
+
+keyspace: cqlstress_smallint_keyspace
+
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS cqlstress_smallint_keyspace 
+  WITH replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
+
+queries:
+  test_query:
+    cql: INSERT INTO cqlstress_smallint_keyspace.test_table (pkey, c1, c2, c3) VALUES (?, ?, ?, ?)

--- a/tools/util/profiles/cqlstress_text_profile.yaml
+++ b/tools/util/profiles/cqlstress_text_profile.yaml
@@ -1,0 +1,19 @@
+table: test_table
+
+table_definition: |
+  CREATE TABLE IF NOT EXISTS test_table (
+    pkey blob PRIMARY KEY,
+    c1 text,
+    c2 text,
+    c3 text
+   );
+
+keyspace: cqlstress_text_keyspace
+
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS cqlstress_text_keyspace 
+  WITH replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
+
+queries:
+  test_query:
+    cql: INSERT INTO cqlstress_text_keyspace.test_table (pkey, c1, c2, c3) VALUES (?, ?, ?, ?)

--- a/tools/util/profiles/cqlstress_tinyint_profile.yaml
+++ b/tools/util/profiles/cqlstress_tinyint_profile.yaml
@@ -1,0 +1,19 @@
+table: test_table
+
+table_definition: |
+  CREATE TABLE IF NOT EXISTS test_table (
+    pkey blob PRIMARY KEY,
+    c1 tinyint,
+    c2 tinyint,
+    c3 tinyint
+   );
+
+keyspace: cqlstress_tinyint_keyspace
+
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS cqlstress_tinyint_keyspace 
+  WITH replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
+
+queries:
+  test_query:
+    cql: INSERT INTO cqlstress_tinyint_keyspace.test_table (pkey, c1, c2, c3) VALUES (?, ?, ?, ?)

--- a/tools/util/profiles/cqlstress_uuid_profile.yaml
+++ b/tools/util/profiles/cqlstress_uuid_profile.yaml
@@ -1,0 +1,19 @@
+table: test_table
+
+table_definition: |
+  CREATE TABLE IF NOT EXISTS test_table (
+    pkey blob PRIMARY KEY,
+    c1 uuid,
+    c2 uuid,
+    c3 uuid
+   );
+
+keyspace: cqlstress_uuid_keyspace
+
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS cqlstress_uuid_keyspace 
+  WITH replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
+
+queries:
+  test_query:
+    cql: INSERT INTO cqlstress_uuid_keyspace.test_table (pkey, c1, c2, c3) VALUES (?, ?, ?, ?)

--- a/tools/util/profiles/cqlstress_varint_profile.yaml
+++ b/tools/util/profiles/cqlstress_varint_profile.yaml
@@ -1,0 +1,19 @@
+table: test_table
+
+table_definition: |
+  CREATE TABLE IF NOT EXISTS test_table (
+    pkey blob PRIMARY KEY,
+    c1 varint,
+    c2 varint,
+    c3 varint
+   );
+
+keyspace: cqlstress_varint_keyspace
+
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS cqlstress_varint_keyspace 
+  WITH replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
+
+queries:
+  test_query:
+    cql: INSERT INTO cqlstress_varint_keyspace.test_table (pkey, c1, c2, c3) VALUES (?, ?, ?, ?)

--- a/tools/util/profiles/cs_bigint_profile.yaml
+++ b/tools/util/profiles/cs_bigint_profile.yaml
@@ -1,0 +1,19 @@
+table: test_table
+
+table_definition: |
+  CREATE TABLE IF NOT EXISTS test_table (
+    pkey blob PRIMARY KEY,
+    c1 bigint,
+    c2 bigint,
+    c3 bigint
+   );
+
+keyspace: cs_bigint_keyspace
+
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS cs_bigint_keyspace 
+  WITH replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
+
+queries:
+  test_query:
+    cql: INSERT INTO cs_bigint_keyspace.test_table (pkey, c1, c2, c3) VALUES (?, ?, ?, ?)

--- a/tools/util/profiles/cs_blob_profile.yaml
+++ b/tools/util/profiles/cs_blob_profile.yaml
@@ -12,7 +12,7 @@ keyspace: cs_blob_keyspace
 
 keyspace_definition: |
   CREATE KEYSPACE IF NOT EXISTS cs_blob_keyspace 
-  WITH replication = { 'class': 'SimpleStrategy', 'replication_factor': 1};
+  WITH replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
 
 queries:
   test_query:

--- a/tools/util/profiles/cs_decimal_profile.yaml
+++ b/tools/util/profiles/cs_decimal_profile.yaml
@@ -1,0 +1,19 @@
+table: test_table
+
+table_definition: |
+  CREATE TABLE IF NOT EXISTS test_table (
+    pkey blob PRIMARY KEY,
+    c1 decimal,
+    c2 decimal,
+    c3 decimal
+   );
+
+keyspace: cs_decimal_keyspace
+
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS cs_decimal_keyspace 
+  WITH replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
+
+queries:
+  test_query:
+    cql: INSERT INTO cs_decimal_keyspace.test_table (pkey, c1, c2, c3) VALUES (?, ?, ?, ?)

--- a/tools/util/profiles/cs_double_profile.yaml
+++ b/tools/util/profiles/cs_double_profile.yaml
@@ -1,0 +1,19 @@
+table: test_table
+
+table_definition: |
+  CREATE TABLE IF NOT EXISTS test_table (
+    pkey blob PRIMARY KEY,
+    c1 double,
+    c2 double,
+    c3 double
+   );
+
+keyspace: cs_double_keyspace
+
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS cs_double_keyspace 
+  WITH replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
+
+queries:
+  test_query:
+    cql: INSERT INTO cs_double_keyspace.test_table (pkey, c1, c2, c3) VALUES (?, ?, ?, ?)

--- a/tools/util/profiles/cs_float_profile.yaml
+++ b/tools/util/profiles/cs_float_profile.yaml
@@ -1,0 +1,19 @@
+table: test_table
+
+table_definition: |
+  CREATE TABLE IF NOT EXISTS test_table (
+    pkey blob PRIMARY KEY,
+    c1 float,
+    c2 float,
+    c3 float
+   );
+
+keyspace: cs_float_keyspace
+
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS cs_float_keyspace 
+  WITH replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
+
+queries:
+  test_query:
+    cql: INSERT INTO cs_float_keyspace.test_table (pkey, c1, c2, c3) VALUES (?, ?, ?, ?)

--- a/tools/util/profiles/cs_inet_profile.yaml
+++ b/tools/util/profiles/cs_inet_profile.yaml
@@ -1,0 +1,19 @@
+table: test_table
+
+table_definition: |
+  CREATE TABLE IF NOT EXISTS test_table (
+    pkey blob PRIMARY KEY,
+    c1 inet,
+    c2 inet,
+    c3 inet
+   );
+
+keyspace: cs_inet_keyspace
+
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS cs_inet_keyspace 
+  WITH replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
+
+queries:
+  test_query:
+    cql: INSERT INTO cs_inet_keyspace.test_table (pkey, c1, c2, c3) VALUES (?, ?, ?, ?)

--- a/tools/util/profiles/cs_int_profile.yaml
+++ b/tools/util/profiles/cs_int_profile.yaml
@@ -1,0 +1,19 @@
+table: test_table
+
+table_definition: |
+  CREATE TABLE IF NOT EXISTS test_table (
+    pkey blob PRIMARY KEY,
+    c1 int,
+    c2 int,
+    c3 int
+   );
+
+keyspace: cs_int_keyspace
+
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS cs_int_keyspace 
+  WITH replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
+
+queries:
+  test_query:
+    cql: INSERT INTO cs_int_keyspace.test_table (pkey, c1, c2, c3) VALUES (?, ?, ?, ?)

--- a/tools/util/profiles/cs_smallint_profile.yaml
+++ b/tools/util/profiles/cs_smallint_profile.yaml
@@ -1,0 +1,19 @@
+table: test_table
+
+table_definition: |
+  CREATE TABLE IF NOT EXISTS test_table (
+    pkey blob PRIMARY KEY,
+    c1 smallint,
+    c2 smallint,
+    c3 smallint
+   );
+
+keyspace: cs_smallint_keyspace
+
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS cs_smallint_keyspace 
+  WITH replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
+
+queries:
+  test_query:
+    cql: INSERT INTO cs_smallint_keyspace.test_table (pkey, c1, c2, c3) VALUES (?, ?, ?, ?)

--- a/tools/util/profiles/cs_text_profile.yaml
+++ b/tools/util/profiles/cs_text_profile.yaml
@@ -1,0 +1,19 @@
+table: test_table
+
+table_definition: |
+  CREATE TABLE IF NOT EXISTS test_table (
+    pkey blob PRIMARY KEY,
+    c1 text,
+    c2 text,
+    c3 text
+   );
+
+keyspace: cs_text_keyspace
+
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS cs_text_keyspace 
+  WITH replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
+
+queries:
+  test_query:
+    cql: INSERT INTO cs_text_keyspace.test_table (pkey, c1, c2, c3) VALUES (?, ?, ?, ?)

--- a/tools/util/profiles/cs_tinyint_profile.yaml
+++ b/tools/util/profiles/cs_tinyint_profile.yaml
@@ -1,0 +1,19 @@
+table: test_table
+
+table_definition: |
+  CREATE TABLE IF NOT EXISTS test_table (
+    pkey blob PRIMARY KEY,
+    c1 tinyint,
+    c2 tinyint,
+    c3 tinyint
+   );
+
+keyspace: cs_tinyint_keyspace
+
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS cs_tinyint_keyspace 
+  WITH replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
+
+queries:
+  test_query:
+    cql: INSERT INTO cs_tinyint_keyspace.test_table (pkey, c1, c2, c3) VALUES (?, ?, ?, ?)

--- a/tools/util/profiles/cs_uuid_profile.yaml
+++ b/tools/util/profiles/cs_uuid_profile.yaml
@@ -1,0 +1,19 @@
+table: test_table
+
+table_definition: |
+  CREATE TABLE IF NOT EXISTS test_table (
+    pkey blob PRIMARY KEY,
+    c1 uuid,
+    c2 uuid,
+    c3 uuid
+   );
+
+keyspace: cs_uuid_keyspace
+
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS cs_uuid_keyspace 
+  WITH replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
+
+queries:
+  test_query:
+    cql: INSERT INTO cs_uuid_keyspace.test_table (pkey, c1, c2, c3) VALUES (?, ?, ?, ?)

--- a/tools/util/profiles/cs_varint_profile.yaml
+++ b/tools/util/profiles/cs_varint_profile.yaml
@@ -1,0 +1,19 @@
+table: test_table
+
+table_definition: |
+  CREATE TABLE IF NOT EXISTS test_table (
+    pkey blob PRIMARY KEY,
+    c1 varint,
+    c2 varint,
+    c3 varint
+   );
+
+keyspace: cs_varint_keyspace
+
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS cs_varint_keyspace 
+  WITH replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
+
+queries:
+  test_query:
+    cql: INSERT INTO cs_varint_keyspace.test_table (pkey, c1, c2, c3) VALUES (?, ?, ?, ?)


### PR DESCRIPTION
Fix: https://github.com/scylladb/cql-stress/issues/78

This PR introduces generator for simple types. These types do not depend on nesting the generators. For more complex types, the `Generator` struct and `ValueGenerator` trait will need to be refactored a bit.

List of the CQL types that I implemented the generators for:
- `text`
- `tinyint`
- `smallint`
- `int`
- `bigint`
- `boolean`
- `float`
- `double`
- `inet`
- `varint`
- `decimal`
- `uuid`

For each type, there is a corresponding test case added to CI.