### PR TITLE
c-s: Implement query/operation sampler

### DIFF
--- a/src/bin/cql-stress-cassandra-stress/operation/user.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/user.rs
@@ -13,15 +13,16 @@ use anyhow::Result;
 
 use crate::{
     java_generate::{
-        distribution::Distribution,
+        distribution::{Distribution, DistributionFactory},
         values::{Generator, GeneratorConfig, ValueGeneratorFactory},
     },
-    settings::CassandraStressSettings,
+    settings::{CassandraStressSettings, OpWeight},
     stats::ShardedStats,
 };
 
 use super::{
     row_generator::RowGenerator, CassandraStressOperation, CassandraStressOperationFactory,
+    OperationSampler,
 };
 
 const SEED_STR: &str = "seed for stress";
@@ -70,49 +71,8 @@ impl CassandraStressOperationFactory for UserDefinedOperationFactory {
     }
 }
 
-/// A struct that samples the operations.
-/// TODO: For now, this is a simple round-robin sampler.
-///       Adjust it, when `ops()` and `clustering=` parameters are supported.
-///       This will need to be somehow unified with the sampler of `mixed` operation.
-///       I think the sampler could cache the row associated with current operation as well.
-struct OperationSampler {
-    op_map: HashMap<String, UserDefinedOperation>,
-    op_keys: Vec<String>,
-    current_operation_index: usize,
-}
-
-impl OperationSampler {
-    fn from_operation_map(op_map: HashMap<String, UserDefinedOperation>) -> Self {
-        let op_keys = op_map.keys().cloned().collect::<Vec<_>>();
-        let current_operation_index = 0;
-
-        Self {
-            op_map,
-            op_keys,
-            current_operation_index,
-        }
-    }
-
-    fn sample(&mut self) -> &UserDefinedOperation {
-        // op_keys is a vector of keys of op_map. This unwrap is safe.
-        let sample = self
-            .op_map
-            .get(&self.op_keys[self.current_operation_index])
-            .unwrap();
-        self.current_operation_index = (self.current_operation_index + 1) % self.op_keys.len();
-        sample
-    }
-
-    fn sample_cached(&self) -> &UserDefinedOperation {
-        // op_keys is a vector of keys of op_map. This unwrap is safe.
-        self.op_map
-            .get(&self.op_keys[self.current_operation_index])
-            .unwrap()
-    }
-}
-
 pub struct UserOperation {
-    sampler: OperationSampler,
+    sampler: OperationSampler<UserDefinedOperation>,
     workload: RowGenerator,
     stats: Arc<ShardedStats>,
     max_operations: Option<u64>,
@@ -130,7 +90,7 @@ impl UserOperation {
         }
 
         let (op, row) = match &mut self.cached_row {
-            Some(cached_row) => (self.sampler.sample_cached(), cached_row),
+            Some(cached_row) => (self.sampler.previous_sample(), cached_row),
             None => {
                 let op = self.sampler.sample();
                 let row = self.cached_row.insert(op.generate_row(&mut self.workload));
@@ -159,10 +119,11 @@ pub struct UserOperationFactory {
     pk_seed_distribution: Arc<dyn Distribution>,
     stats: Arc<ShardedStats>,
     table_metadata: Table,
-    statements_map: HashMap<String, PreparedStatement>,
+    queries_payload: HashMap<String, (PreparedStatement, OpWeight)>,
     pk_generator_factory: Box<dyn ValueGeneratorFactory>,
     column_generator_factories: Vec<Box<dyn ValueGeneratorFactory>>,
     max_operations: Option<u64>,
+    clustering: Arc<dyn DistributionFactory>,
 }
 
 impl UserOperationFactory {
@@ -197,11 +158,11 @@ impl UserOperationFactory {
             "Compound partition keys are not yet supported by the tool!"
         );
 
-        let mut statements_map = HashMap::new();
-        for (q_name, (q_def, _weight)) in query_definitions {
-            statements_map.insert(
+        let mut queries_payload = HashMap::new();
+        for (q_name, (q_def, weight)) in query_definitions {
+            queries_payload.insert(
                 q_name.to_owned(),
-                q_def.to_prepared_statement(&session).await?,
+                (q_def.to_prepared_statement(&session).await?, *weight),
             );
         }
 
@@ -235,10 +196,11 @@ impl UserOperationFactory {
             pk_seed_distribution,
             stats,
             table_metadata,
-            statements_map,
+            queries_payload,
             max_operations,
             pk_generator_factory,
             column_generator_factories,
+            clustering: user_profile.clustering.clone(),
         })
     }
 
@@ -277,10 +239,10 @@ impl OperationFactory for UserOperationFactory {
     fn create(&self) -> Box<dyn Operation> {
         let workload = self.create_workload();
 
-        let operations_map: HashMap<String, UserDefinedOperation> =
-            self.statements_map
+        let weights_iter =
+            self.queries_payload
                 .iter()
-                .map(|(op_name, stmt)| {
+                .map(|(_op_name, (stmt, weight))| {
                     let variable_metadata = stmt.get_variable_col_specs();
                     let argument_index = variable_metadata
                         .iter()
@@ -291,17 +253,16 @@ impl OperationFactory for UserOperationFactory {
                         })
                         .collect::<Vec<_>>();
                     (
-                        op_name.clone(),
                         UserDefinedOperation {
                             session: Arc::clone(&self.session),
                             statement: stmt.clone(),
                             argument_index,
                         },
+                        *weight,
                     )
-                })
-                .collect::<HashMap<_, _>>();
+                });
 
-        let sampler = OperationSampler::from_operation_map(operations_map);
+        let sampler = OperationSampler::new(weights_iter, self.clustering.as_ref());
 
         Box::new(UserOperation {
             workload,

--- a/src/bin/cql-stress-cassandra-stress/operation/user.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/user.rs
@@ -174,7 +174,7 @@ impl UserOperationFactory {
         // We parsed a user command. This unwrap is safe.
         let user_profile = settings.command_params.user.as_ref().unwrap();
 
-        let query_definitions = &user_profile.queries;
+        let query_definitions = &user_profile.queries_payload;
         let cluster_data = session.get_cluster_data();
         let table_metadata = cluster_data
             .get_keyspace_info()
@@ -198,7 +198,7 @@ impl UserOperationFactory {
         );
 
         let mut statements_map = HashMap::new();
-        for (q_name, q_def) in query_definitions {
+        for (q_name, (q_def, _weight)) in query_definitions {
             statements_map.insert(
                 q_name.to_owned(),
                 q_def.to_prepared_statement(&session).await?,

--- a/src/bin/cql-stress-cassandra-stress/settings/command/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/mod.rs
@@ -22,6 +22,8 @@ use self::counter::CounterParams;
 use self::mixed::print_help_mixed;
 use self::mixed::MixedParams;
 #[cfg(feature = "user-profile")]
+pub use self::user::OpWeight;
+#[cfg(feature = "user-profile")]
 use self::user::UserParams;
 pub use help::print_help;
 

--- a/src/bin/cql-stress-cassandra-stress/settings/command/test_user_profile_yamls/full_profile.yaml
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/test_user_profile_yamls/full_profile.yaml
@@ -16,7 +16,7 @@ table_definition:
 queries:
   ins:
     cql: insert into standard1 (pkey, ckey, c1) values (?, ?, ?)
-    consistencyLevel: local
+    consistencyLevel: local_one
     serialConsistencyLevel: local_serial
   read:
     cql: select c1 from standard1 where pkey = ?

--- a/src/bin/cql-stress-cassandra-stress/settings/command/user.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/user.rs
@@ -54,6 +54,7 @@ impl QueryDefinitionYaml {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct QueryDefinition {
     pub cql: String,
     pub consistency: Option<Consistency>,

--- a/src/bin/cql-stress-cassandra-stress/settings/command/user.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/user.rs
@@ -274,7 +274,7 @@ mod tests {
             "insert into standard1 (pkey, ckey, c1) values (?, ?, ?)",
             ins_query.cql
         );
-        assert_eq!(Some("local".to_string()), ins_query.consistency_level);
+        assert_eq!(Some("local_one".to_string()), ins_query.consistency_level);
         assert_eq!(
             Some("local_serial".to_string()),
             ins_query.serial_consistency_level

--- a/src/bin/cql-stress-cassandra-stress/settings/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/mod.rs
@@ -12,6 +12,8 @@ mod test;
 pub use command::Command;
 pub use command::CommandParams;
 pub use command::MixedSubcommand;
+#[cfg(feature = "user-profile")]
+pub use command::OpWeight;
 pub use command::OperationRatio;
 pub use option::ThreadsInfo;
 use regex::Regex;

--- a/tools/util/cassandra_stress.py
+++ b/tools/util/cassandra_stress.py
@@ -117,11 +117,3 @@ class CqlStressCassandraStress(CSCliRunner):
         stress_cmd = ["cargo", "run", "--features", "user-profile", "--bin",
                       "cql-stress-cassandra-stress", "--"]
         super().__init__(stress_cmd=stress_cmd)
-
-    def prepare_user_args(self, node_ip, profile_name, query_name=DEFAULT_TEST_QUERY_NAME, runtime_args: CSCliRuntimeArguments = DEFAULT_RUNTIME_ARGUMENTS):
-        full_profile_name = os.path.join(TEST_PROFILES_DIRECTORY, profile_name)
-        return ["user", f"profile={full_profile_name}",
-                "no-warmup", f"n={runtime_args.workload_size}",
-                "-node", node_ip,
-                "-rate", f"threads={runtime_args.concurrency}",
-                f"-pop seq=1..{runtime_args.workload_size}"]


### PR DESCRIPTION
Fix: https://github.com/scylladb/cql-stress/issues/80

This PR extends a CLI for user command by `ops()` and `clustering=` parameters.

The semantics of parameters:
- `ops` -> defines a ratio with which the operation/queries will be
    sampled. For example `ops(foo=1,bar=2)` means that the tool will
    approximately execute 2 `bar` queries per 1 `foo` query. These queries
    must be defined in the profile yaml.
- `clustering` -> a distribution. The tool will sample a value from
  this distribution to decide how many times to execute
  current operation/query (which was sampled based on `ops`). The value
  will be treated as a counter. When counter reaches 0, new operation
  is sampled, and so, the new value of counter is sampled as well.

The struct that will make use of these parameters is `OperationSampler`. At first, I wanted to implement it in a way so it can be used for both `user` and `mixed` commands. The reason for this is that `mixed` command supports two analogous parameters: `ratio` and `clustering`. However, due to the Rust language limitations it's really hard (or even impossible) to implement the operation sampler this way. `CassandraStressOperation` trait declares async methods, thus it is not object-safe, and so we cannot create trait objects based on this trait (`Box<dyn CassandraStressOperation>`).

I decided to leave the code for `mixed` command as is for now.