### PR TITLE
CI: fix clippy issues

### DIFF
--- a/src/bin/cql-stress-scylla-bench/gocompat/strconv.rs
+++ b/src/bin/cql-stress-scylla-bench/gocompat/strconv.rs
@@ -352,8 +352,6 @@ mod tests {
 
     #[test]
     fn test_parse_uint_good() {
-        use std::{u32, u64};
-
         let tests_32: &[(&str, u32)] = &[
             // Zeros
             ("0", 0),
@@ -402,8 +400,6 @@ mod tests {
 
     #[test]
     fn test_parse_uint_bad() {
-        use std::u64;
-
         let tests_32: &[&str] = &[
             // Invalid characters
             "abcd",
@@ -444,8 +440,6 @@ mod tests {
 
     #[test]
     fn test_parse_int_good() {
-        use std::i32;
-
         let tests_32: &[(&str, i32)] = &[
             // Zero
             ("0", 0),

--- a/src/bin/cql-stress-scylla-bench/main.rs
+++ b/src/bin/cql-stress-scylla-bench/main.rs
@@ -302,7 +302,7 @@ fn create_workload_factory(args: &ScyllaBenchArgs) -> Result<Box<dyn WorkloadFac
         }
         (WorkloadType::Timeseries, Mode::Write) => {
             let tsw_config = TimeseriesWriteConfig {
-                partition_offset: args.partition_offset,
+                _partition_offset: args.partition_offset,
                 pks_per_generation: args.partition_count,
                 cks_per_pk: args.clustering_row_count,
                 start_nanos: args.start_timestamp,
@@ -313,7 +313,7 @@ fn create_workload_factory(args: &ScyllaBenchArgs) -> Result<Box<dyn WorkloadFac
         (WorkloadType::Timeseries, Mode::Read) => {
             let period = 1_000_000_000 / args.write_rate;
             let tsr_config = TimeseriesReadConfig {
-                partition_offset: args.partition_offset,
+                _partition_offset: args.partition_offset,
                 pks_per_generation: args.partition_count,
                 cks_per_pk: args.clustering_row_count,
                 start_nanos: args.start_timestamp,

--- a/src/bin/cql-stress-scylla-bench/operation/scan.rs
+++ b/src/bin/cql-stress-scylla-bench/operation/scan.rs
@@ -91,7 +91,7 @@ impl ScanOperation {
         let calc_bound = |idx: u64| {
             let shifted = (idx as u128) << 64;
             let biased = shifted / self.args.range_count as u128;
-            biased as i64 + std::i64::MIN
+            biased as i64 + i64::MIN
         };
 
         let range_begin = calc_bound(range_idx);

--- a/src/bin/cql-stress-scylla-bench/workload/timeseries_read.rs
+++ b/src/bin/cql-stress-scylla-bench/workload/timeseries_read.rs
@@ -28,7 +28,8 @@ struct TimeseriesRead {
 
 #[derive(Clone)]
 pub struct TimeseriesReadConfig {
-    pub partition_offset: i64,
+    // FIXME: why is this not used??
+    pub _partition_offset: i64,
     pub pks_per_generation: u64,
     pub cks_per_pk: u64,
     pub start_nanos: u64,

--- a/src/bin/cql-stress-scylla-bench/workload/timeseries_write.rs
+++ b/src/bin/cql-stress-scylla-bench/workload/timeseries_write.rs
@@ -22,7 +22,7 @@ struct TimeseriesWrite {
 
 #[derive(Clone)]
 pub struct TimeseriesWriteConfig {
-    pub partition_offset: i64,
+    pub _partition_offset: i64,
     pub pks_per_generation: u64,
     pub cks_per_pk: u64,
     pub start_nanos: u64,


### PR DESCRIPTION
There were two issues clippy was complaining about:
- use of legacy numeric types (i.e. `std::{u32. u64}`)
- unused field in `Timeseries{Read/Write}Config` structs (no idea why this wasn't recognized before)

This PR fixes these issues.