### PR TITLE
c-s: Implement `insert` operation for user profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Commands mentioned above are very limited. They do not, for example, allow to te
 
 To test more complex schemas, make use of user profiles (`user` command). User profiles allow to define custom schemas and custom statements used to stress the database.
 
+Users can define custom statements via user profile yaml file. See the exemplary yaml files under `tools/util/profiles`. The path to profile file can be provided via `profile=` parameter of `user` command.
+
+Notice that the tool reserves an `insert` operation name and predefines the behaviour
+of this operation. User can execute this operation (with a given sample ratio weight)
+by providing it to `ops()` parameter along with other operations defined by the user in the yaml file. This operation will simply generate and insert a full row to the stressed table. It's analogous to `write` command - the only difference is that it operates on the custom schema.
+
 To enable the `user` mode, the tool needs to be compiled with `user-profile` feature. This feature is enabled by default.
 
 ## Development

--- a/src/bin/cql-stress-cassandra-stress/operation/user.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/user.rs
@@ -202,6 +202,18 @@ impl UserOperationFactory {
                 );
             }
 
+            println!("\n========================");
+            println!("Operations to be performed and their sample ratio weights:\n");
+            for (q_name, (statement, q_weight)) in queries_payload.iter() {
+                println!(
+                    "- {}: {{ 'cql': '{}', 'weight': {} }}",
+                    q_name,
+                    statement.get_statement(),
+                    q_weight
+                );
+            }
+            println!("========================\n");
+
             queries_payload
         };
 

--- a/src/bin/cql-stress-cassandra-stress/settings/command/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/mod.rs
@@ -22,9 +22,9 @@ use self::counter::CounterParams;
 use self::mixed::print_help_mixed;
 use self::mixed::MixedParams;
 #[cfg(feature = "user-profile")]
-pub use self::user::OpWeight;
-#[cfg(feature = "user-profile")]
 use self::user::UserParams;
+#[cfg(feature = "user-profile")]
+pub use self::user::{OpWeight, PREDEFINED_INSERT_OPERATION};
 pub use help::print_help;
 
 use super::ParsePayload;

--- a/src/bin/cql-stress-cassandra-stress/settings/command/test_user_profile_yamls/insert_query_profile.yaml
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/test_user_profile_yamls/insert_query_profile.yaml
@@ -1,0 +1,7 @@
+# This file contains an 'insert' query, thus it's invalid.
+# This is a reserved name for an operation - the tool predefines its behaviour.
+keyspace: foo
+table: bar
+queries:
+  insert:
+    cql: select c1 from standard1 where pkey = ?

--- a/src/bin/cql-stress-cassandra-stress/settings/command/user.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/user.rs
@@ -317,6 +317,15 @@ mod tests {
     }
 
     #[test]
+    fn insert_query_profile_yaml_contents_test() {
+        // 'insert' is a reserved name for an operation. Parsing should fail.
+        let yaml_filepath = build_file_path("insert_query_profile.yaml");
+
+        let profile = UserProfile::parse(&yaml_filepath);
+        assert!(profile.is_err());
+    }
+
+    #[test]
     fn full_profile_yaml_contents_test() {
         let yaml_filepath = build_file_path("full_profile.yaml");
 

--- a/src/bin/cql-stress-cassandra-stress/settings/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/mod.rs
@@ -13,9 +13,9 @@ mod test;
 pub use command::Command;
 pub use command::CommandParams;
 pub use command::MixedSubcommand;
-#[cfg(feature = "user-profile")]
-pub use command::OpWeight;
 pub use command::OperationRatio;
+#[cfg(feature = "user-profile")]
+pub use command::{OpWeight, PREDEFINED_INSERT_OPERATION};
 pub use option::ThreadsInfo;
 use regex::Regex;
 use scylla::Session;


### PR DESCRIPTION
Fix: https://github.com/scylladb/cql-stress/issues/91

This PR introduces a logic for predefined `insert` operation.

Changes:
- adjusted CLI to support `insert` operation for `user` command. Users can now choose to perform this operation (with a given sample ratio weight) via `ops()` parameter.
- implemented runtime logic for `insert` operation. As the name suggests, the operation simply generates a row and inserts it to database.
- updated README
- TODO: implement runtime tests in python