### PR TITLE
mixed: prepare statements only for subcommands defined by user

### DIFF
--- a/src/bin/cql-stress-cassandra-stress/java_generate/distribution/enumerated.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/distribution/enumerated.rs
@@ -19,6 +19,12 @@ impl<T: Copy> EnumeratedDistribution<T> {
     }
 }
 
+impl<T: PartialEq + Eq> EnumeratedDistribution<T> {
+    pub fn contains(&self, t: &T) -> bool {
+        self.items.iter().any(|(item, _weight)| item == t)
+    }
+}
+
 impl<T: std::fmt::Display> std::fmt::Display for EnumeratedDistribution<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{{")?;

--- a/src/bin/cql-stress-cassandra-stress/operation/mixed.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/mixed.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use futures::Future;
 use std::{ops::ControlFlow, sync::Arc};
 
 use cql_stress::{
@@ -26,10 +27,10 @@ use super::{
 };
 
 pub struct MixedOperation {
-    write_operation: WriteOperation,
-    counter_write_operation: CounterWriteOperation,
-    read_operation: RegularReadOperation,
-    counter_read_operation: CounterReadOperation,
+    write_operation: Option<WriteOperation>,
+    counter_write_operation: Option<CounterWriteOperation>,
+    read_operation: Option<RegularReadOperation>,
+    counter_read_operation: Option<CounterReadOperation>,
     cached_row: Option<Vec<CqlValue>>,
     workload: RowGenerator,
     max_operations: Option<u64>,
@@ -42,24 +43,30 @@ pub struct MixedOperation {
 
 pub struct MixedOperationFactory {
     settings: Arc<CassandraStressSettings>,
-    write_operation_factory: WriteOperationFactory,
-    counter_write_operation_factory: CounterWriteOperationFactory,
-    read_operation_factory: RegularReadOperationFactory,
-    counter_read_operation_factory: CounterReadOperationFactory,
+    write_operation_factory: Option<WriteOperationFactory>,
+    counter_write_operation_factory: Option<CounterWriteOperationFactory>,
+    read_operation_factory: Option<RegularReadOperationFactory>,
+    counter_read_operation_factory: Option<CounterReadOperationFactory>,
     operation_ratio: Arc<OperationRatio>,
     workload_factory: RowGeneratorFactory,
     max_operations: Option<u64>,
     stats: Arc<ShardedStats>,
 }
 
+fn create_operation_opt<Factory: CassandraStressOperationFactory>(
+    factory_opt: &Option<Factory>,
+) -> Option<Factory::Operation> {
+    factory_opt.as_ref().map(|f| f.create())
+}
+
 impl OperationFactory for MixedOperationFactory {
     fn create(&self) -> Box<dyn Operation> {
         let mixed_params = self.settings.command_params.mixed.as_ref().unwrap();
 
-        let write_operation = self.write_operation_factory.create();
-        let counter_write_operation = self.counter_write_operation_factory.create();
-        let read_operation = self.read_operation_factory.create();
-        let counter_read_operation = self.counter_read_operation_factory.create();
+        let write_operation = create_operation_opt(&self.write_operation_factory);
+        let counter_write_operation = create_operation_opt(&self.counter_write_operation_factory);
+        let read_operation = create_operation_opt(&self.read_operation_factory);
+        let counter_read_operation = create_operation_opt(&self.counter_read_operation_factory);
 
         Box::new(MixedOperation {
             write_operation,
@@ -88,16 +95,46 @@ impl MixedOperationFactory {
         let mixed_params = settings.command_params.mixed.as_ref().unwrap();
         let max_operations = settings.command_params.common.operation_count;
         let operation_ratio = Arc::new(mixed_params.operation_ratio.clone());
-        let write_operation_factory =
-            WriteOperationFactory::new(settings.clone(), session.clone()).await?;
-        let counter_write_operation_factory =
-            CounterWriteOperationFactory::new(settings.clone(), session.clone()).await?;
-        let read_operation_factory =
-            RegularReadOperationFactory::new(settings.clone(), session.clone(), DEFAULT_TABLE_NAME)
-                .await?;
-        let counter_read_operation_factory =
-            CounterReadOperationFactory::new(settings.clone(), session, DEFAULT_COUNTER_TABLE_NAME)
-                .await?;
+        let write_operation_factory = Self::conditional_create_factory(
+            &mixed_params.operation_ratio,
+            &MixedSubcommand::Write,
+            || WriteOperationFactory::new(settings.clone(), session.clone()),
+        )
+        .await
+        .transpose()?;
+        let counter_write_operation_factory = Self::conditional_create_factory(
+            &mixed_params.operation_ratio,
+            &MixedSubcommand::CounterWrite,
+            || CounterWriteOperationFactory::new(settings.clone(), session.clone()),
+        )
+        .await
+        .transpose()?;
+        let read_operation_factory = Self::conditional_create_factory(
+            &mixed_params.operation_ratio,
+            &MixedSubcommand::Read,
+            || {
+                RegularReadOperationFactory::new(
+                    settings.clone(),
+                    session.clone(),
+                    DEFAULT_TABLE_NAME,
+                )
+            },
+        )
+        .await
+        .transpose()?;
+        let counter_read_operation_factory = Self::conditional_create_factory(
+            &mixed_params.operation_ratio,
+            &MixedSubcommand::CounterRead,
+            || {
+                CounterReadOperationFactory::new(
+                    settings.clone(),
+                    session.clone(),
+                    DEFAULT_COUNTER_TABLE_NAME,
+                )
+            },
+        )
+        .await
+        .transpose()?;
 
         Ok(Self {
             settings,
@@ -110,6 +147,18 @@ impl MixedOperationFactory {
             max_operations,
             stats,
         })
+    }
+
+    async fn conditional_create_factory<Factory, Fut: Future<Output = Result<Factory>>>(
+        ratios: &OperationRatio,
+        command_kind: &MixedSubcommand,
+        create_factory_fut: impl FnOnce() -> Fut,
+    ) -> Option<Result<Factory>> {
+        if ratios.contains(command_kind) {
+            Some(create_factory_fut().await)
+        } else {
+            None
+        }
     }
 }
 
@@ -129,31 +178,39 @@ impl MixedOperation {
                 (self.clustering_distribution.next_i64() as usize).max(1);
         }
 
+        // FIXME: Get rid of these unwraps once async traits are considered object-safe.
         let result = match &self.current_operation {
             MixedSubcommand::Read => {
+                // This is safe. We create a given operation only if corresponding `MixedSubcommand` is defined in `operation_ratio` map.
+                let read_operation = self.read_operation.as_ref().unwrap();
                 let row = self
                     .cached_row
-                    .get_or_insert_with(|| self.read_operation.generate_row(&mut self.workload));
-                self.read_operation.execute(row).await
+                    .get_or_insert_with(|| read_operation.generate_row(&mut self.workload));
+                read_operation.execute(row).await
             }
             MixedSubcommand::CounterRead => {
-                let row = self.cached_row.get_or_insert_with(|| {
-                    self.counter_read_operation.generate_row(&mut self.workload)
-                });
-                self.counter_read_operation.execute(row).await
-            }
-            MixedSubcommand::Write => {
+                // This is safe. We create a given operation only if corresponding `MixedSubcommand` is defined in `operation_ratio` map.
+                let counter_read_operation = self.counter_read_operation.as_ref().unwrap();
                 let row = self
                     .cached_row
-                    .get_or_insert_with(|| self.write_operation.generate_row(&mut self.workload));
-                self.write_operation.execute(row).await
+                    .get_or_insert_with(|| counter_read_operation.generate_row(&mut self.workload));
+                counter_read_operation.execute(row).await
+            }
+            MixedSubcommand::Write => {
+                // This is safe. We create a given operation only if corresponding `MixedSubcommand` is defined in `operation_ratio` map.
+                let write_operation = self.write_operation.as_ref().unwrap();
+                let row = self
+                    .cached_row
+                    .get_or_insert_with(|| write_operation.generate_row(&mut self.workload));
+                write_operation.execute(row).await
             }
             MixedSubcommand::CounterWrite => {
+                // This is safe. We create a given operation only if corresponding `MixedSubcommand` is defined in `operation_ratio` map.
+                let counter_write_operation = self.counter_write_operation.as_ref().unwrap();
                 let row = self.cached_row.get_or_insert_with(|| {
-                    self.counter_write_operation
-                        .generate_row(&mut self.workload)
+                    counter_write_operation.generate_row(&mut self.workload)
                 });
-                self.counter_write_operation.execute(row).await
+                counter_write_operation.execute(row).await
             }
         };
 


### PR DESCRIPTION
# Motivation

See the discussion: https://github.com/scylladb/cql-stress/pull/86#issuecomment-2204524664.

My last PR (https://github.com/scylladb/cql-stress/pull/86) introduced a new bug - `mixed` command tries to prepare a statement for each operation (read/write/counter_read/counter_write), even though it does not create the tables.

This PR fixes it so we prepare the statements only for the operations that are going to be sampled (were specified in `ratio()` parameter by the user). We obviously then assume that the corresponding write workload was ran beforehand and that it created tables used by the `mixed` workload.