### PR TITLE
clippy: fix indentation issues in docstring

### DIFF
--- a/src/bin/cql-stress-cassandra-stress/java_generate/values/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/java_generate/values/mod.rs
@@ -180,6 +180,7 @@ pub trait ValueGenerator: Send + Sync + 'static {
 /// [`ValueGenerator`] once the native type is deduced from metadata.
 ///
 /// - Why not just clone a ValueGenerator once created?
+///
 /// Since we make use of trait objects, we cannot expect [`ValueGenerator`]
 /// to implement [`Clone`] as well.
 #[cfg(feature = "user-profile")]

--- a/src/bin/cql-stress-cassandra-stress/operation/row_generator.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/row_generator.rs
@@ -35,6 +35,7 @@ use super::recompute_seed;
 /// In c-s, there are only two deterministic distributions:
 /// - FIXED
 /// - SEQ
+///
 /// We call a distribution non-deterministic if the values it samples in each run may differ. It's the case
 /// for all of the distributions that depend on some RNG (which is by default seeded with current time in millis)
 /// e.g. UniformDistribution, GaussianDistribution (not yet implemented).


### PR DESCRIPTION
Clippy (1.81.0) is complaining about indendation issues for docstring statements following a list. The list, and the following statement should be separated by an empty line.