### PR TITLE
cargo: bump rust-driver version to 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.8"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -333,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.8"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
@@ -347,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.8"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
@@ -636,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1191,9 +1191,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scylla"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9439d92eea9f86c07175c819c3a129ca28b02477b47df26db354a1f4ea7ee276"
+checksum = "8139623d3fb0c8205b15e84fa587f3aa0ba61f876c19a9157b688f7c1763a7c5"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1224,9 +1224,9 @@ dependencies = [
 
 [[package]]
 name = "scylla-cql"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64037fb9d9c59ae15137fff9a56c4d528908dfd38d09e75b5f8e56e3894966dd"
+checksum = "de7020bcd1f6fdbeaed356cd426bf294b2071bd7120d48d2e8e319295e2acdcd"
 dependencies = [
  "async-trait",
  "bigdecimal",
@@ -1243,9 +1243,9 @@ dependencies = [
 
 [[package]]
 name = "scylla-macros"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5fe1d389adebe6a1a27bce18b81a65ff18c25d58a795de490e18b0e7a27b9f"
+checksum = "3859b6938663fc5062e3b26f3611649c9bd26fb252e85f6fdfa581e0d2ce74b6"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1359,9 +1359,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rand = "0.8"
 rand_distr = "0.4"
 rand_pcg = "0.3"
 regex = "1.9.1"
-scylla = { version = "0.13.0", features = ["ssl"] }
+scylla = { version = "0.14.0", features = ["ssl"] }
 sha2 = "0.10"
 strum = "0.25.0"
 strum_macros = "0.25.1"
@@ -47,7 +47,7 @@ user-profile = ["dep:serde", "dep:serde_yaml", "dep:uuid"]
 ntest = "0.8"
 num-bigint = "0.4"
 bigdecimal = "0.4"
-scylla = { version = "0.13.0", features = [
+scylla = { version = "0.14.0", features = [
     "ssl",
     "num-bigint-04",
     "bigdecimal-04",

--- a/src/bin/cql-stress-cassandra-stress/operation/counter_write.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/counter_write.rs
@@ -29,7 +29,8 @@ impl CassandraStressOperation for CounterWriteOperation {
     type Factory = CounterWriteOperationFactory;
 
     async fn execute(&self, row: &[CqlValue]) -> Result<ControlFlow<()>> {
-        let result = self.session.execute(&self.statement, row).await;
+        // execute_unpaged, since it's an UPDATE statement.
+        let result = self.session.execute_unpaged(&self.statement, row).await;
 
         if let Err(err) = result.as_ref() {
             tracing::error!(

--- a/src/bin/cql-stress-cassandra-stress/operation/user.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/user.rs
@@ -43,7 +43,11 @@ impl CassandraStressOperation for UserDefinedOperation {
             bound_row.push(&row[*i]);
         }
 
-        self.session.execute(&self.statement, bound_row).await?;
+        // User can provide a custom query here. In addition, we don't care
+        // about the result of this query. This is why we can use `execute_unpaged`.
+        self.session
+            .execute_unpaged(&self.statement, bound_row)
+            .await?;
 
         Ok(ControlFlow::Continue(()))
     }

--- a/src/bin/cql-stress-cassandra-stress/operation/write.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/write.rs
@@ -23,7 +23,8 @@ impl CassandraStressOperation for WriteOperation {
     type Factory = WriteOperationFactory;
 
     async fn execute(&self, row: &[CqlValue]) -> Result<ControlFlow<()>> {
-        let result = self.session.execute(&self.statement, &row).await;
+        // execute_unpaged, since it's an INSERT statement.
+        let result = self.session.execute_unpaged(&self.statement, &row).await;
 
         if let Err(err) = result.as_ref() {
             tracing::error!(

--- a/src/bin/cql-stress-cassandra-stress/settings/command/user.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/user.rs
@@ -139,7 +139,7 @@ impl UserParams {
     pub async fn create_schema(&self, session: &Session) -> Result<()> {
         if let Some(keyspace_definition) = &self.keyspace_definition {
             session
-                .query(keyspace_definition.as_str(), ())
+                .query_unpaged(keyspace_definition.as_str(), ())
                 .await
                 .context("Failed to create keyspace based on user profile")?;
         }
@@ -147,7 +147,7 @@ impl UserParams {
 
         if let Some(table_definition) = &self.table_definition {
             session
-                .query(table_definition.as_str(), ())
+                .query_unpaged(table_definition.as_str(), ())
                 .await
                 .context("Failed to create table based on user profile")?;
         }

--- a/src/bin/cql-stress-cassandra-stress/settings/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/mod.rs
@@ -62,7 +62,7 @@ impl CassandraStressSettings {
 
         if matches!(self.command, Command::Write | Command::CounterWrite) {
             session
-                .query(self.schema.construct_keyspace_creation_query(), ())
+                .query_unpaged(self.schema.construct_keyspace_creation_query(), ())
                 .await?;
         }
 
@@ -71,7 +71,7 @@ impl CassandraStressSettings {
         match self.command {
             Command::Write => {
                 session
-                    .query(
+                    .query_unpaged(
                         self.schema
                             .construct_table_creation_query(&self.column.columns),
                         (),
@@ -81,7 +81,7 @@ impl CassandraStressSettings {
             }
             Command::CounterWrite => {
                 session
-                    .query(
+                    .query_unpaged(
                         self.schema
                             .construct_counter_table_creation_query(&self.column.columns),
                         (),

--- a/src/bin/cql-stress-scylla-bench/main.rs
+++ b/src/bin/cql-stress-scylla-bench/main.rs
@@ -207,7 +207,7 @@ async fn create_schema(session: &Session, args: &ScyllaBenchArgs) -> Result<()> 
         {{'class': 'SimpleStrategy', 'replication_factor': {}}}",
         args.keyspace_name, args.replication_factor,
     );
-    session.query(create_keyspace_query_str, ()).await?;
+    session.query_unpaged(create_keyspace_query_str, ()).await?;
     session.use_keyspace(&args.keyspace_name, true).await?;
     session.await_schema_agreement().await?;
 
@@ -217,7 +217,7 @@ async fn create_schema(session: &Session, args: &ScyllaBenchArgs) -> Result<()> 
         WITH compression = {{ }}",
         args.table_name,
     );
-    let q1 = session.query(create_regular_table_query_str, ());
+    let q1 = session.query_unpaged(create_regular_table_query_str, ());
 
     let create_counter_table_query_str = format!(
         "CREATE TABLE IF NOT EXISTS {} \
@@ -225,7 +225,7 @@ async fn create_schema(session: &Session, args: &ScyllaBenchArgs) -> Result<()> 
         WITH compression = {{ }}",
         args.counter_table_name,
     );
-    let q2 = session.query(create_counter_table_query_str, ());
+    let q2 = session.query_unpaged(create_counter_table_query_str, ());
 
     future::try_join(q1, q2).await?;
     session.await_schema_agreement().await?;

--- a/src/bin/cql-stress-scylla-bench/operation/counter_update.rs
+++ b/src/bin/cql-stress-scylla-bench/operation/counter_update.rs
@@ -90,8 +90,9 @@ impl CounterUpdateOperation {
 
 impl CounterUpdateOperation {
     async fn write_single(&mut self, pk: i64, ck: i64) -> Result<()> {
+        // execute_npaged, since it's an UPDATE statement.
         self.session
-            .execute(
+            .execute_unpaged(
                 &self.statement,
                 (ck + 1, ck + 2, ck + 3, ck + 4, ck + 5, pk, ck),
             )

--- a/src/bin/cql-stress-scylla-bench/operation/write.rs
+++ b/src/bin/cql-stress-scylla-bench/operation/write.rs
@@ -114,8 +114,9 @@ impl WriteOperation {
 impl WriteOperation {
     async fn write_single(&mut self, pk: i64, ck: i64) -> Result<()> {
         let data = self.generate_row(pk, ck);
+        // execute_unpaged, since it's an INSERT statement.
         self.session
-            .execute(&self.statement, (pk, ck, data))
+            .execute_unpaged(&self.statement, (pk, ck, data))
             .await?;
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,10 +12,13 @@ pub mod sharded_stats;
 #[cfg(test)]
 mod tests {
     use crate::test_util::new_test_session;
+    use scylla::transport::PagingState;
 
     #[tokio::test]
     async fn test_can_connect() {
         let s = new_test_session().await;
-        s.query("SELECT * FROM system.local", ()).await.unwrap();
+        s.query_single_page("SELECT * FROM system.local", (), PagingState::start())
+            .await
+            .unwrap();
     }
 }


### PR DESCRIPTION
The only API breaking changes that needed to be addressed were rust driver's changes regarding query/execute API changes regarding paging.

We changed `query/execute` calls to `[query/execute]_unpaged` calls, adding the comments explaining why it makes sense to make use of unpaged queries in these places (unless it is obvious).