### PR TITLE
feature(hdrh_logger): added hdr histograms logger

### DIFF
--- a/src/bin/cql-stress-cassandra-stress/hdr_logger.rs
+++ b/src/bin/cql-stress-cassandra-stress/hdr_logger.rs
@@ -1,0 +1,79 @@
+use std::{fs::File, path::Path, time::SystemTime};
+
+use crate::stats::Stats;
+use anyhow::Result;
+use cql_stress::version::get_version_info;
+use hdrhistogram::serialization::interval_log;
+use hdrhistogram::Histogram;
+use tokio::time::Instant;
+
+/// Writes histogram data to a file using HDR format.
+///
+/// This struct manages a log writer for recording performance histograms,
+/// tracking the start time and last write time for accurate timing.
+pub struct HdrLogWriter {
+    log_writer: interval_log::IntervalLogWriter<
+        'static,
+        'static,
+        File,
+        hdrhistogram::serialization::V2Serializer,
+    >,
+    start_timestamp: Instant,
+    last_hdr_write: Instant,
+}
+
+impl HdrLogWriter {
+    pub fn new<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let file = File::create(path)?;
+        let start_time = SystemTime::now();
+
+        let serializer = Box::new(hdrhistogram::serialization::V2Serializer::new());
+        // Note: Box::leak is used to satisfy 'static lifetime requirements of IntervalLogWriter.
+        let log_writer = interval_log::IntervalLogWriterBuilder::new()
+            .add_comment(
+                format!(
+                    "[Logged with Cql-stress {}]",
+                    get_version_info().cql_stress_version
+                )
+                .as_str(),
+            )
+            .with_start_time(start_time)
+            .with_base_time(start_time)
+            .with_max_value_divisor(1000000.0)
+            .begin_log_with(Box::leak(Box::new(file)), Box::leak(serializer))
+            .unwrap();
+
+        Ok(Self {
+            log_writer,
+            start_timestamp: Instant::now(),
+            last_hdr_write: Instant::now(),
+        })
+    }
+
+    /// Writes combined statistics histograms to the HDR log file.
+    ///
+    /// # Arguments
+    /// * `partial_stats` - The statistics containing histograms to log.
+    ///
+    /// # Errors
+    /// Returns an error if writing to the log file fails.
+    pub fn write_to_hdr_log(&mut self, partial_stats: &Stats) -> Result<()> {
+        let duration = self.last_hdr_write.elapsed();
+        let elapsed = self.start_timestamp.elapsed();
+
+        let mut tag_histograms: Vec<(&String, &Histogram<u64>)> =
+            partial_stats.get_histograms().iter().collect();
+        tag_histograms.sort_by(|(tag_a, _), (tag_b, _)| tag_a.cmp(tag_b));
+
+        for (tag, histogram) in tag_histograms {
+            self.log_writer.write_histogram(
+                histogram,
+                elapsed,
+                duration,
+                interval_log::Tag::new(tag),
+            )?;
+        }
+        self.last_hdr_write = Instant::now();
+        Ok(())
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/operation/counter_write.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/counter_write.rs
@@ -54,6 +54,10 @@ impl CassandraStressOperation for CounterWriteOperation {
         values.push(pk);
         values
     }
+
+    fn operation_tag(&self) -> &'static str {
+        "COUNTER_WRITE"
+    }
 }
 
 impl CassandraStressOperationFactory for CounterWriteOperationFactory {

--- a/src/bin/cql-stress-cassandra-stress/operation/mixed.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/mixed.rs
@@ -186,7 +186,13 @@ impl MixedOperation {
                 let row = self
                     .cached_row
                     .get_or_insert_with(|| read_operation.generate_row(&mut self.workload));
-                read_operation.execute(row).await
+                let result = read_operation.execute(row).await;
+                self.stats.get_shard_mut().account_operation(
+                    ctx,
+                    &result,
+                    read_operation.operation_tag(),
+                );
+                result
             }
             MixedSubcommand::CounterRead => {
                 // This is safe. We create a given operation only if corresponding `MixedSubcommand` is defined in `operation_ratio` map.
@@ -194,7 +200,13 @@ impl MixedOperation {
                 let row = self
                     .cached_row
                     .get_or_insert_with(|| counter_read_operation.generate_row(&mut self.workload));
-                counter_read_operation.execute(row).await
+                let result = counter_read_operation.execute(row).await;
+                self.stats.get_shard_mut().account_operation(
+                    ctx,
+                    &result,
+                    counter_read_operation.operation_tag(),
+                );
+                result
             }
             MixedSubcommand::Write => {
                 // This is safe. We create a given operation only if corresponding `MixedSubcommand` is defined in `operation_ratio` map.
@@ -202,7 +214,13 @@ impl MixedOperation {
                 let row = self
                     .cached_row
                     .get_or_insert_with(|| write_operation.generate_row(&mut self.workload));
-                write_operation.execute(row).await
+                let result = write_operation.execute(row).await;
+                self.stats.get_shard_mut().account_operation(
+                    ctx,
+                    &result,
+                    write_operation.operation_tag(),
+                );
+                result
             }
             MixedSubcommand::CounterWrite => {
                 // This is safe. We create a given operation only if corresponding `MixedSubcommand` is defined in `operation_ratio` map.
@@ -210,11 +228,15 @@ impl MixedOperation {
                 let row = self.cached_row.get_or_insert_with(|| {
                     counter_write_operation.generate_row(&mut self.workload)
                 });
-                counter_write_operation.execute(row).await
+                let result = counter_write_operation.execute(row).await;
+                self.stats.get_shard_mut().account_operation(
+                    ctx,
+                    &result,
+                    counter_write_operation.operation_tag(),
+                );
+                result
             }
         };
-
-        self.stats.get_shard_mut().account_operation(ctx, &result);
 
         if result.is_ok() {
             self.current_operation_remaining -= 1;

--- a/src/bin/cql-stress-cassandra-stress/operation/read.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/read.rs
@@ -70,6 +70,10 @@ impl<V: RowValidator> CassandraStressOperation for ReadOperation<V> {
     fn generate_row(&self, row_generator: &mut RowGenerator) -> Vec<CqlValue> {
         row_generator.generate_row()
     }
+
+    fn operation_tag(&self) -> &'static str {
+        V::operation_tag()
+    }
 }
 
 impl<V: RowValidator> CassandraStressOperationFactory for GenericReadOperationFactory<V> {

--- a/src/bin/cql-stress-cassandra-stress/operation/write.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/write.rs
@@ -43,6 +43,10 @@ impl CassandraStressOperation for WriteOperation {
     fn generate_row(&self, row_generator: &mut RowGenerator) -> Vec<CqlValue> {
         row_generator.generate_row()
     }
+
+    fn operation_tag(&self) -> &'static str {
+        "WRITE"
+    }
 }
 
 impl CassandraStressOperationFactory for WriteOperationFactory {

--- a/src/bin/cql-stress-cassandra-stress/settings/cs_args_bad_test.in
+++ b/src/bin/cql-stress-cassandra-stress/settings/cs_args_bad_test.in
@@ -45,3 +45,5 @@ cassandra-stress mixed ratio(mixed=1)
 cassandra-stress mixed ratio()
 cassandra-stress read ratio(read=1,write=2)
 cassandra-stress read clustering=FIXED(2)
+
+cassandra-stress read -log interval=1h

--- a/src/bin/cql-stress-cassandra-stress/settings/cs_args_good_test.in
+++ b/src/bin/cql-stress-cassandra-stress/settings/cs_args_good_test.in
@@ -35,11 +35,14 @@ cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1, key=value)
 cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1, key=value) -rate threads=10 -col size=fixed(50) -pop dist=UNIFORM(1..10) -mode cql3 native compression=snappy connectionsPerShard=3
 cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1, key=value) -rate threads=10 -col size=fixed(50) -pop dist=UNIFORM(1..10) -mode cql3 native compression=lz4 connectionsPerHost=3
 cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1, key=value) -rate threads=10 -col size=fixed(50) -pop dist=UNIFORM(1..10) -mode cql3 native compression=none connectionsPerHost=3 user=cassandra password=cassandra
+cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1, key=value) -rate threads=10 -col size=fixed(50) -pop dist=UNIFORM(1..10) -mode cql3 native compression=none connectionsPerHost=3 user=cassandra password=cassandra
 
 # This tests the case sensitivity of throttle= parameter's value. We should accept both /S and /s.
-cassandra-stress read no-warmup cl=QUORUM duration=600M -rate threads=80 throttle=8000/S
 
 cassandra-stress mixed ratio(read=1,write=1) clustering=FIXED(10)
 cassandra-stress mixed ratio(read=1)
 cassandra-stress version
 cassandra-stress version_json
+
+cassandra-stress write -log interval=5s
+cassandra-stress write -log interval=5s hdrfile=hdr.log

--- a/src/bin/cql-stress-cassandra-stress/settings/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/mod.rs
@@ -16,6 +16,7 @@ pub use command::MixedSubcommand;
 pub use command::OperationRatio;
 #[cfg(feature = "user-profile")]
 pub use command::{OpWeight, PREDEFINED_INSERT_OPERATION};
+pub use option::LogOption;
 pub use option::ThreadsInfo;
 use regex::Regex;
 use scylla::client::session::Session;
@@ -39,6 +40,7 @@ pub struct CassandraStressSettings {
     pub schema: SchemaOption,
     pub column: ColumnOption,
     pub population: PopulationOption,
+    pub log: LogOption,
 }
 
 impl CassandraStressSettings {
@@ -51,6 +53,7 @@ impl CassandraStressSettings {
         self.schema.print_settings();
         self.column.print_settings();
         self.population.print_settings();
+        self.log.print_settings();
         println!();
     }
 
@@ -213,6 +216,7 @@ where
         let mode = ModeOption::parse(&mut payload)?;
         let schema = SchemaOption::parse(&mut payload)?;
         let column = ColumnOption::parse(&mut payload)?;
+        let log = LogOption::parse(&mut payload)?;
 
         // The default distribution (if not specified) is SEQ(1..operation_count).
         // If operation_count is not specified, then the default is 1M.
@@ -252,6 +256,7 @@ where
                 schema,
                 column,
                 population,
+                log,
             },
         )))
     };

--- a/src/bin/cql-stress-cassandra-stress/settings/option/log.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/option/log.rs
@@ -1,0 +1,147 @@
+use anyhow::Result;
+use std::{path::PathBuf, time::Duration};
+
+use crate::settings::{
+    param::{types::IntervalMillisOrSeconds, ParamsParser, SimpleParamHandle},
+    ParsePayload,
+};
+
+#[derive(Clone, Debug)]
+pub struct LogOption {
+    pub hdr_file: Option<PathBuf>,
+    pub interval: Duration,
+}
+
+impl Default for LogOption {
+    fn default() -> Self {
+        Self {
+            hdr_file: None,
+            interval: Duration::from_secs(1),
+        }
+    }
+}
+
+impl LogOption {
+    pub const CLI_STRING: &'static str = "-log";
+
+    pub fn description() -> &'static str {
+        "Specify logging options"
+    }
+
+    pub fn parse(cl_args: &mut ParsePayload) -> Result<Self> {
+        let params = cl_args.remove(Self::CLI_STRING).unwrap_or_default();
+        let (parser, handles) = prepare_parser();
+        parser.parse(params)?;
+        Self::from_handles(handles)
+    }
+
+    pub fn print_help() {
+        let (parser, _) = prepare_parser();
+        parser.print_help();
+    }
+
+    pub fn print_settings(&self) {
+        println!("Log:");
+        if let Some(path) = &self.hdr_file {
+            println!("  HDR Histogram file: {}", path.display());
+        }
+        println!("  Log interval: {:?}", self.interval);
+    }
+
+    fn from_handles(handles: LogParamHandles) -> Result<Self> {
+        let hdr_file = handles.hdr_file.get().map(PathBuf::from);
+        let interval = handles.interval.get().unwrap_or(Duration::from_secs(1));
+
+        Ok(Self { hdr_file, interval })
+    }
+}
+
+struct LogParamHandles {
+    pub hdr_file: SimpleParamHandle<String>,
+    pub interval: SimpleParamHandle<IntervalMillisOrSeconds>,
+}
+
+fn prepare_parser() -> (ParamsParser, LogParamHandles) {
+    let mut parser = ParamsParser::new(LogOption::CLI_STRING);
+
+    let hdr_file = parser.simple_param(
+        "hdrfile=",
+        None,
+        "Log HDR Histogram data to the specified file",
+        false,
+    );
+
+    let interval = parser.simple_param(
+        "interval=",
+        Some("1s"),
+        "Set the interval between logs in seconds or milliseconds",
+        false,
+    );
+
+    parser.group(&[&hdr_file, &interval]);
+
+    (parser, LogParamHandles { hdr_file, interval })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::prepare_parser;
+
+    #[test]
+    fn log_default_params_test() {
+        let args = vec![];
+        let (parser, handles) = prepare_parser();
+
+        assert!(parser.parse(args).is_ok());
+
+        let params = super::LogOption::from_handles(handles).unwrap();
+        assert_eq!(None, params.hdr_file);
+        assert_eq!(Duration::from_secs(1), params.interval);
+    }
+
+    #[test]
+    fn log_good_params_test() {
+        let args = vec!["hdrfile=test.hdr", "interval=500ms"];
+        let (parser, handles) = prepare_parser();
+
+        assert!(parser.parse(args).is_ok());
+
+        let params = super::LogOption::from_handles(handles).unwrap();
+        assert!(params.hdr_file.is_some());
+        assert_eq!("test.hdr", params.hdr_file.unwrap().to_str().unwrap());
+        assert_eq!(Duration::from_millis(500), params.interval);
+    }
+
+    #[test]
+    fn log_seconds_interval_test() {
+        let args = vec!["interval=5s"];
+        let (parser, handles) = prepare_parser();
+
+        assert!(parser.parse(args).is_ok());
+
+        let params = super::LogOption::from_handles(handles).unwrap();
+        assert_eq!(Duration::from_secs(5), params.interval);
+    }
+
+    #[test]
+    fn log_plain_interval_test() {
+        let args = vec!["interval=10"];
+        let (parser, handles) = prepare_parser();
+
+        assert!(parser.parse(args).is_ok());
+
+        let params = super::LogOption::from_handles(handles).unwrap();
+        assert_eq!(Duration::from_secs(10), params.interval);
+    }
+
+    #[test]
+    fn log_bad_interval_test() {
+        let args = vec!["interval=foo"];
+        let (parser, _) = prepare_parser();
+
+        // Should fail with an invalid interval format
+        assert!(parser.parse(args).is_err());
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/settings/option/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/option/mod.rs
@@ -1,4 +1,5 @@
 mod column;
+mod log;
 mod mode;
 mod node;
 mod population;
@@ -8,6 +9,7 @@ mod schema;
 use anyhow::Result;
 
 pub use column::ColumnOption;
+pub use log::LogOption;
 pub use mode::ModeOption;
 pub use node::NodeOption;
 pub use population::PopulationOption;
@@ -29,6 +31,7 @@ impl Options {
                 PopulationOption::CLI_STRING,
                 PopulationOption::description(),
             ),
+            (LogOption::CLI_STRING, LogOption::description()),
         ]
         .into_iter()
     }
@@ -48,6 +51,7 @@ impl Options {
             ColumnOption::CLI_STRING => ColumnOption::print_help(),
             PopulationOption::CLI_STRING => PopulationOption::print_help(),
             ModeOption::CLI_STRING => ModeOption::print_help(),
+            LogOption::CLI_STRING => LogOption::print_help(),
             _ => return Err(anyhow::anyhow!("Invalid option provided to command help")),
         }
 

--- a/src/bin/cql-stress-cassandra-stress/settings/param/types.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/types.rs
@@ -373,6 +373,38 @@ impl Parsable for RatioMap {
     }
 }
 
+/// Parses an interval value with optional millisecond or second suffix.
+/// Valid formats: "123" (seconds), "123s" (seconds), "123ms" (milliseconds)
+pub struct IntervalMillisOrSeconds;
+
+impl Parsable for IntervalMillisOrSeconds {
+    type Parsed = std::time::Duration;
+
+    fn parse(s: &str) -> Result<Self::Parsed> {
+        ensure_regex!(s, r"^[0-9]+(ms|s|)$");
+
+        if s.ends_with("ms") {
+            // Parse milliseconds
+            let ms_str = &s[0..s.len() - 2];
+            let ms = ms_str
+                .parse::<u64>()
+                .with_context(|| format!("Invalid millisecond value: {}", ms_str))?;
+            Ok(Duration::from_millis(ms))
+        } else {
+            // Parse seconds (either with "s" suffix or without suffix)
+            let sec_str = if s.ends_with('s') {
+                &s[0..s.len() - 1]
+            } else {
+                s
+            };
+            let sec = sec_str
+                .parse::<u64>()
+                .with_context(|| format!("Invalid second value: {}", sec_str))?;
+            Ok(Duration::from_secs(sec))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{

--- a/tools/cql-stress-cassandra-stress-ci.py
+++ b/tools/cql-stress-cassandra-stress-ci.py
@@ -5,14 +5,18 @@ from util.scylla_docker import ScyllaDockerNode
 from util.cassandra_stress import CassandraStress, CqlStressCassandraStress, CSCliRuntimeArguments
 from test_cs_write_and_validate import run as run_write_and_validate
 from test_cs_equal_db import run as run_equal_db, run_user
+from test_hdr_logging import run as run_hdr_logging
 
 
 # Utils for test cases
 
 @pytest.fixture
 def default_runtime_args():
-    return CSCliRuntimeArguments(workload_size="100", concurrency="1")
+    return CSCliRuntimeArguments(workload_size="100", concurrency="1", hdr_log_file=None, log_interval=1)
 
+@pytest.fixture
+def hdr_log_runtime_args():
+    return CSCliRuntimeArguments(workload_size="30000", concurrency="2", hdr_log_file="test.hdr", log_interval=1)
 
 DEFAULT_SCYLLA_URI = "127.0.0.1:9042"
 
@@ -40,6 +44,11 @@ def test_write_and_validate(default_runtime_args, scylla_docker_node,
                             cassandra_stress, cql_stress):
     run_write_and_validate(runtime_args=default_runtime_args, node=scylla_docker_node,
                            cs=cassandra_stress, cql_stress=cql_stress)
+
+def test_write_and_validate_with_hdr_log(hdr_log_runtime_args, scylla_docker_node,
+                                        cql_stress):
+    run_hdr_logging(runtime_args=hdr_log_runtime_args, node=scylla_docker_node,
+                           cql_stress=cql_stress)
 
 
 def test_equal_db(default_runtime_args, scylla_docker_node,

--- a/tools/test_hdr_logging.py
+++ b/tools/test_hdr_logging.py
@@ -1,0 +1,144 @@
+#! /usr/bin/env python3
+
+import os
+from util.cassandra_stress import CqlStressCassandraStress
+from util.cassandra_stress import generate_random_keyspaces, CSCliRuntimeArguments
+from util.scylla_docker import ScyllaDockerNode
+
+# This test verifies that HDR logging functionality works correctly
+
+
+def check_hdr_file_valid(file_path, expected_interval=1):
+    """Check if HDR log file has been created and has valid content."""
+    print(f"Checking HDR file: {file_path}")
+    if not os.path.exists(file_path):
+        print(f"ERROR: HDR file {file_path} does not exist!")
+        return False
+
+    # Check file size - should be non-empty
+    file_size = os.path.getsize(file_path)
+    print(f"HDR file size: {file_size} bytes")
+    if file_size == 0:
+        print(f"ERROR: HDR file {file_path} is empty!")
+        return False
+
+    # Validate file contents
+    try:
+        with open(file_path, 'r') as f:
+            lines = f.readlines()
+        
+        if len(lines) < 5:
+            print(f"ERROR: HDR file has too few lines ({len(lines)})")
+            return False
+        
+        # Validate header comments
+        expected_headers = [
+            "Logged with Cql-stress",
+            "#[StartTime:",
+            "#[BaseTime:",
+            "#[MaxValueDivisor:",
+        ]
+        
+        for i, expected in enumerate(expected_headers):
+            if i >= len(lines):
+                print(f"ERROR: Missing header line: {expected}")
+                return False
+            if expected not in lines[i]:
+                print(f"ERROR: Header mismatch. Expected '{expected}' in line: {lines[i].strip()}")
+                return False
+                
+        print("All header lines validated successfully")
+        
+        # Validate data rows
+        if len(lines) <= 4:
+            print("WARNING: No data rows found in HDR file")
+            return True  # Still return True as the file format is valid, just empty
+            
+        data_rows = lines[4:]
+        last_timestamp = None
+        
+        for i, row in enumerate(data_rows):
+            # Skip empty lines
+            if not row.strip():
+                continue
+                
+            # Example row: Tag=write,5.449,5.002,4.944,<data>
+            parts = row.split(',')
+            
+            # Last row might be shorter due to end of the test
+            is_last_row = (i == len(data_rows) - 1)
+            if not is_last_row and len(parts) < 4:
+                print(f"ERROR: Invalid data row format: {row.strip()}")
+                return False
+                
+            # Validate tag presence
+            if not parts[0].startswith("Tag="):
+                print(f"ERROR: Missing tag in row: {row.strip()}")
+                return False
+                
+            try:
+                # Get timestamp and interval length
+                timestamp = float(parts[1])
+                interval_length = float(parts[2])
+                tolerance = 0.1  # 0.1 second tolerance
+                
+                # First row validation
+                if i == 0:
+                    # First timestamp should be around expected_interval 
+                    if timestamp < expected_interval - tolerance or timestamp > expected_interval + tolerance:
+                        print(f"ERROR: First timestamp {timestamp} is not close to expected interval {expected_interval}")
+                        return False
+                
+                # Subsequent rows validation - skip validation for last row
+                if last_timestamp is not None and not is_last_row:
+                    # Check if this timestamp is approximately last_timestamp + interval_length
+                    expected_timestamp = last_timestamp + expected_interval
+                    
+                    if abs(timestamp - expected_timestamp) > tolerance:
+                        print(f"ERROR: Timestamp {timestamp} does not match expected {expected_timestamp} (previous + interval)")
+                        return False
+                
+                # Check if interval length is close to expected interval - skip validation for last row
+                if not is_last_row and abs(interval_length - expected_interval) > tolerance:
+                    print(f"ERROR: Interval length {interval_length} is not close to expected {expected_interval}")
+                    return False
+                    
+                last_timestamp = timestamp
+                
+            except ValueError as e:
+                print(f"ERROR: Invalid numeric data in row: {row.strip()} - {e}")
+                return False
+                
+        print(f"Successfully validated {len(data_rows)} data rows")
+        return True
+        
+    except Exception as e:
+        print(f"ERROR: Failed to validate HDR file contents: {e}")
+        return False
+
+
+def run(runtime_args: CSCliRuntimeArguments, node: ScyllaDockerNode,
+        cql_stress: CqlStressCassandraStress):
+    keyspaces = generate_random_keyspaces()
+    ks_cqlstress = keyspaces.ks_cqlstress
+
+    # Create a temporary directory for HDR log files if no hdr_log_file provided
+    hdr_file = runtime_args.hdr_log_file
+
+    print("\n=== Starting the HDR logging test... ===")
+    print(f"\n=== Running cql-stress with log interval ({runtime_args.log_interval}s) ===\n")
+    
+    # Run the stress test
+    cql_stress.run(
+        command="write",
+        node_ip=node.ip,
+        keyspace=ks_cqlstress,
+        runtime_args=runtime_args
+    )
+    
+    # Verify HDR file was created
+    if not check_hdr_file_valid(hdr_file, expected_interval=runtime_args.log_interval):
+        raise RuntimeError("HDR log test failed")
+
+    print("\n=== HDR logging test successful ===\n")
+

--- a/tools/util/cassandra_stress.py
+++ b/tools/util/cassandra_stress.py
@@ -20,16 +20,25 @@ Keyspaces = namedtuple("Keyspaces", ["ks_cassandra", "ks_cqlstress"])
 
 
 CSCliRuntimeArguments = namedtuple("CSCliRuntimeArguments", [
-                                   "workload_size", "concurrency"])
+                                   "workload_size", "concurrency", "hdr_log_file", "log_interval"])
 DEFAULT_RUNTIME_ARGUMENTS = CSCliRuntimeArguments(
-    workload_size=100, concurrency=1)
+    workload_size=100, concurrency=1, hdr_log_file=None, log_interval=1)
 
 
 def prepare_args(command, node_ip, keyspace, runtime_args: CSCliRuntimeArguments = DEFAULT_RUNTIME_ARGUMENTS):
-    return [command, "no-warmup", f"n={runtime_args.workload_size}",
+    args = [command, "no-warmup", f"n={runtime_args.workload_size}",
             "-node", node_ip,
             "-rate", f"threads={runtime_args.concurrency}",
             "-schema", f"keyspace={keyspace}"]
+
+    # Add HDR logging options if specified
+    if runtime_args.hdr_log_file:
+        log_args = ["-log", f"hdrfile={runtime_args.hdr_log_file}"]
+        if runtime_args.log_interval != 1:  # Only add if not the default
+            log_args.append(f"interval={runtime_args.log_interval}")
+        args.extend(log_args)
+
+    return args
 
 
 # Default query name used in test profiles.


### PR DESCRIPTION
Introduced hdr histogram file logger supporting different types of statement (read, write, couter_read, counter_write). Also handling `-log interval` for proper granularity.

closes: https://github.com/scylladb/cql-stress/issues/103