### PR TITLE
fix(rate): adjusted -rate option to match c-s

### DIFF
--- a/src/bin/cql-stress-cassandra-stress/settings/cs_args_bad_test.in
+++ b/src/bin/cql-stress-cassandra-stress/settings/cs_args_bad_test.in
@@ -9,7 +9,7 @@ cassandra-stress foo
 cassandra-stress help foo
 cassandra-stress write cl=local_one cl=quorum
 cassandra-stress write cl=quorum no-warmup -node 127.0.0.1,192.168.0.1,
-cassandra-stress write -rate fixed=10/s threads>=10
+cassandra-stress write -rate fixed=10/s throttle=10/s threads>=10
 cassandra-stress read -schema replication(factor=abc)
 cassandra-stress read -schema replication(factor==123)
 cassandra-stress read -schema replication(factor=1,=)

--- a/src/bin/cql-stress-cassandra-stress/settings/cs_args_good_test.in
+++ b/src/bin/cql-stress-cassandra-stress/settings/cs_args_good_test.in
@@ -13,6 +13,7 @@ cassandra-stress counter_write
 cassandra-stress help
 cassandra-stress help read
 cassandra-stress read no-warmup cl=QUORUM duration=600m -rate threads=80 throttle=8000/s
+cassandra-stress read no-warmup cl=QUORUM duration=600m -rate threads=80 fixed=8000/s
 cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1) -rate threads=10
 cassandra-stress read cl=QUORUM n=10000 -schema replication(key=value) -rate threads=10
 cassandra-stress read cl=QUORUM n=10000 -schema replication(factor=1, key=value) -rate threads=10


### PR DESCRIPTION
Seems `-rate` fixed option changed in c-s and this code reflects that change:
 if `fixed=op/s` is set, it enables `co_fixed` flag and when `throttle=op/s` is used `co_fixed` flag is `false`

fixes: https://github.com/scylladb/cql-stress/issues/108