### PR TITLE
feature(c-s): add -transport option support

### DIFF
--- a/src/bin/cql-stress-cassandra-stress/main.rs
+++ b/src/bin/cql-stress-cassandra-stress/main.rs
@@ -22,6 +22,7 @@ use cql_stress::{
     sharded_stats::StatsFactory as _,
 };
 use hdr_logger::HdrLogWriter;
+
 #[cfg(feature = "user-profile")]
 use operation::UserOperationFactory;
 use operation::{
@@ -156,6 +157,11 @@ async fn prepare_run(
 
     if let Some(creds) = &settings.mode.user_credentials {
         builder = builder.user(&creds.username, &creds.password);
+    }
+
+    if settings.transport.truststore.is_some() || settings.transport.keystore.is_some() {
+        let ssl_ctx = settings.transport.generate_ssl_context()?;
+        builder = builder.tls_context(Some(ssl_ctx));
     }
 
     let default_exec_profile = ExecutionProfile::builder()

--- a/src/bin/cql-stress-cassandra-stress/settings/cs_args_bad_test.in
+++ b/src/bin/cql-stress-cassandra-stress/settings/cs_args_bad_test.in
@@ -47,3 +47,12 @@ cassandra-stress read ratio(read=1,write=2)
 cassandra-stress read clustering=FIXED(2)
 
 cassandra-stress read -log interval=1h
+
+# --- BEGIN: SSL/TLS -transport negative cases ---
+cassandra-stress write -transport truststore=
+cassandra-stress write -transport keystore=
+cassandra-stress write -transport hostname-verification=maybe
+cassandra-stress write -transport foo=bar
+cassandra-stress write -transport garbage
+
+# --- END: SSL/TLS -transport negative cases ---

--- a/src/bin/cql-stress-cassandra-stress/settings/cs_args_good_test.in
+++ b/src/bin/cql-stress-cassandra-stress/settings/cs_args_good_test.in
@@ -47,3 +47,18 @@ cassandra-stress version_json
 
 cassandra-stress write -log interval=5s
 cassandra-stress write -log interval=5s hdrfile=hdr.log
+
+# --- BEGIN: SSL/TLS -transport positive cases ---
+cassandra-stress write -transport truststore=/etc/scylla/ca.crt keystore=/etc/scylla/db.crt hostname-verification=false
+cassandra-stress write -transport truststore=/etc/scylla/ca.crt keystore=/etc/scylla/db.crt hostname-verification=1
+cassandra-stress write -transport truststore=/etc/scylla/ca.crt
+cassandra-stress write -transport keystore=/etc/scylla/db.crt
+cassandra-stress write -transport truststore=/etc/scylla/ca.crt keystore=/etc/scylla/db.crt ssl-protocol=TLS
+cassandra-stress write -transport truststore=/etc/scylla/ca.crt keystore=/etc/scylla/db.crt ssl-alg=SunX509 store-type=JKS ssl-ciphers=TLS_RSA_WITH_AES_128_CBC_SHA
+# Combination of supported and ignored options (should warn but not fail)
+cassandra-stress write -transport truststore=/etc/scylla/ca.crt,keystore=/etc/scylla/db.crt,ssl-protocol=TLS,ssl-alg=SunX509,store-type=JKS,ssl-ciphers=TLS_RSA_WITH_AES_128_CBC_SHA,hostname-verification=true
+# Only hostname-verification
+cassandra-stress write -transport hostname-verification=true
+# Only -transport with no suboptions (should be accepted and default to no SSL)
+cassandra-stress write -transport
+# --- END: SSL/TLS -transport positive cases ---

--- a/src/bin/cql-stress-cassandra-stress/settings/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/mod.rs
@@ -30,6 +30,7 @@ use self::option::NodeOption;
 use self::option::PopulationOption;
 use self::option::RateOption;
 use self::option::SchemaOption;
+use self::option::TransportOption;
 
 pub struct CassandraStressSettings {
     pub command: Command,
@@ -41,6 +42,7 @@ pub struct CassandraStressSettings {
     pub column: ColumnOption,
     pub population: PopulationOption,
     pub log: LogOption,
+    pub transport: TransportOption,
 }
 
 impl CassandraStressSettings {
@@ -54,6 +56,7 @@ impl CassandraStressSettings {
         self.column.print_settings();
         self.population.print_settings();
         self.log.print_settings();
+        self.transport.print_settings();
         println!();
     }
 
@@ -217,6 +220,7 @@ where
         let schema = SchemaOption::parse(&mut payload)?;
         let column = ColumnOption::parse(&mut payload)?;
         let log = LogOption::parse(&mut payload)?;
+        let transport = TransportOption::parse(&mut payload)?;
 
         // The default distribution (if not specified) is SEQ(1..operation_count).
         // If operation_count is not specified, then the default is 1M.
@@ -257,6 +261,7 @@ where
                 column,
                 population,
                 log,
+                transport,
             },
         )))
     };

--- a/src/bin/cql-stress-cassandra-stress/settings/option/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/option/mod.rs
@@ -5,6 +5,7 @@ mod node;
 mod population;
 mod rate;
 mod schema;
+mod transport;
 
 use anyhow::Result;
 
@@ -16,6 +17,7 @@ pub use population::PopulationOption;
 pub use rate::RateOption;
 pub use rate::ThreadsInfo;
 pub use schema::SchemaOption;
+pub use transport::TransportOption;
 
 pub struct Options;
 
@@ -32,6 +34,7 @@ impl Options {
                 PopulationOption::description(),
             ),
             (LogOption::CLI_STRING, LogOption::description()),
+            (TransportOption::CLI_STRING, TransportOption::description()),
         ]
         .into_iter()
     }
@@ -52,6 +55,9 @@ impl Options {
             PopulationOption::CLI_STRING => PopulationOption::print_help(),
             ModeOption::CLI_STRING => ModeOption::print_help(),
             LogOption::CLI_STRING => LogOption::print_help(),
+            TransportOption::CLI_STRING => {
+                TransportOption::print_help();
+            }
             _ => return Err(anyhow::anyhow!("Invalid option provided to command help")),
         }
 

--- a/src/bin/cql-stress-cassandra-stress/settings/option/transport.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/option/transport.rs
@@ -1,0 +1,204 @@
+use crate::settings::param::types::{FlagNumericOrBool, NonEmptyString, NotSupported};
+use crate::settings::param::{ParamsParser, SimpleParamHandle};
+use anyhow::Result;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Default)]
+pub struct TransportOption {
+    pub factory: Option<NotSupported>,
+    pub truststore: Option<String>,
+    pub truststore_password: Option<NotSupported>,
+    pub keystore: Option<String>,
+    pub keystore_password: Option<NotSupported>,
+    pub ssl_protocol: Option<NotSupported>,
+    pub ssl_alg: Option<NotSupported>,
+    pub store_type: Option<NotSupported>,
+    pub ssl_ciphers: Option<NotSupported>,
+    pub hostname_verification: Option<bool>,
+}
+
+struct TransportParamHandles {
+    factory: SimpleParamHandle<NotSupported>,
+    truststore: SimpleParamHandle<NonEmptyString>,
+    truststore_password: SimpleParamHandle<NotSupported>,
+    keystore: SimpleParamHandle<NonEmptyString>,
+    keystore_password: SimpleParamHandle<NotSupported>,
+    ssl_protocol: SimpleParamHandle<NotSupported>,
+    ssl_alg: SimpleParamHandle<NotSupported>,
+    store_type: SimpleParamHandle<NotSupported>,
+    ssl_ciphers: SimpleParamHandle<NotSupported>,
+    hostname_verification: SimpleParamHandle<FlagNumericOrBool>,
+}
+
+fn prepare_parser() -> (ParamsParser, TransportParamHandles) {
+    let mut parser = ParamsParser::new(TransportOption::CLI_STRING);
+    let factory = parser.simple_param("factory=", None, "SSL factory class (unsupported)", false);
+    let truststore = parser.simple_param("truststore=", None, "Path to truststore file", false);
+    let truststore_password = parser.simple_param(
+        "truststore-password=",
+        None,
+        "Truststore password (unsupported)",
+        false,
+    );
+    let keystore = parser.simple_param("keystore=", None, "Path to keystore file", false);
+    let keystore_password = parser.simple_param(
+        "keystore-password=",
+        None,
+        "Keystore password (unsupported)",
+        false,
+    );
+    let ssl_protocol =
+        parser.simple_param("ssl-protocol=", None, "SSL protocol (unsupported)", false);
+    let ssl_alg = parser.simple_param("ssl-alg=", None, "SSL algorithm (unsupported)", false);
+    let store_type = parser.simple_param("store-type=", None, "Store type (unsupported)", false);
+    let ssl_ciphers = parser.simple_param("ssl-ciphers=", None, "SSL ciphers (unsupported)", false);
+    let hostname_verification = parser.simple_param(
+        "hostname-verification=",
+        None,
+        "Enable hostname verification (true/false/1/0)",
+        false,
+    );
+    parser.group(&[
+        &factory,
+        &truststore,
+        &truststore_password,
+        &keystore,
+        &keystore_password,
+        &ssl_protocol,
+        &ssl_alg,
+        &store_type,
+        &ssl_ciphers,
+        &hostname_verification,
+    ]);
+    (
+        parser,
+        TransportParamHandles {
+            factory,
+            truststore,
+            truststore_password,
+            keystore,
+            keystore_password,
+            ssl_protocol,
+            ssl_alg,
+            store_type,
+            ssl_ciphers,
+            hostname_verification,
+        },
+    )
+}
+
+impl TransportOption {
+    pub const CLI_STRING: &'static str = "-transport";
+
+    pub fn parse(payload: &mut HashMap<String, Vec<&str>>) -> Result<Self> {
+        let params = payload.remove(Self::CLI_STRING).unwrap_or_default();
+        let (parser, handles) = prepare_parser();
+        parser.parse(params)?;
+        TransportOption::from_handles(handles)
+    }
+
+    fn from_handles(handles: TransportParamHandles) -> Result<TransportOption> {
+        let factory = handles.factory.get();
+        let truststore = handles.truststore.get();
+        let truststore_password = handles.truststore_password.get();
+        let keystore = handles.keystore.get();
+        let keystore_password = handles.keystore_password.get();
+        let ssl_protocol = handles.ssl_protocol.get();
+        let ssl_alg = handles.ssl_alg.get();
+        let store_type = handles.store_type.get();
+        let ssl_ciphers = handles.ssl_ciphers.get();
+        let hostname_verification = handles.hostname_verification.get();
+
+        Ok(TransportOption {
+            factory,
+            truststore,
+            truststore_password,
+            keystore,
+            keystore_password,
+            ssl_protocol,
+            ssl_alg,
+            store_type,
+            ssl_ciphers,
+            hostname_verification,
+        })
+    }
+
+    pub fn print_settings(&self) {
+        println!("Transport settings:");
+        if self.factory.is_some() {
+            println!("  factory: (unsupported)");
+        }
+        if let Some(ref v) = self.truststore {
+            println!("  truststore: {}", v);
+        }
+        if self.truststore_password.is_some() {
+            println!("  truststore-password: (unsupported)");
+        }
+        if let Some(ref v) = self.keystore {
+            println!("  keystore: {}", v);
+        }
+        if self.keystore_password.is_some() {
+            println!("  keystore-password: (unsupported)");
+        }
+        if self.ssl_protocol.is_some() {
+            println!("  ssl-protocol: (unsupported)");
+        }
+        if self.ssl_alg.is_some() {
+            println!("  ssl-alg: (unsupported)");
+        }
+        if self.store_type.is_some() {
+            println!("  store-type: (unsupported)");
+        }
+        if self.ssl_ciphers.is_some() {
+            println!("  ssl-ciphers: (unsupported)");
+        }
+        if let Some(v) = self.hostname_verification {
+            println!("  hostname-verification: {}", v);
+        }
+    }
+
+    pub fn description() -> &'static str {
+        "transport and SSL options"
+    }
+
+    pub fn print_help() {
+        let (parser, _) = prepare_parser();
+        parser.print_help();
+    }
+
+    pub fn generate_ssl_context(&self) -> anyhow::Result<openssl::ssl::SslContext> {
+        use anyhow::Context;
+        use openssl::ssl::{SslContextBuilder, SslFiletype, SslMethod, SslVerifyMode};
+        use std::fs;
+
+        let mut builder = SslContextBuilder::new(SslMethod::tls())?;
+        builder.set_verify(match self.hostname_verification {
+            Some(true) => SslVerifyMode::PEER,
+            _ => SslVerifyMode::NONE,
+        });
+
+        if let Some(ref truststore) = self.truststore {
+            let ca_path = fs::canonicalize(truststore).with_context(|| {
+                format!("Failed to canonicalize truststore path: {}", truststore)
+            })?;
+            builder
+                .set_ca_file(&ca_path)
+                .with_context(|| format!("Failed to set CA file: {}", ca_path.display()))?;
+        }
+        if let Some(ref keystore) = self.keystore {
+            let key_path = fs::canonicalize(keystore)
+                .with_context(|| format!("Failed to canonicalize keystore path: {}", keystore))?;
+            builder
+                .set_certificate_file(&key_path, SslFiletype::PEM)
+                .with_context(|| {
+                    format!("Failed to set certificate file: {}", key_path.display())
+                })?;
+            builder
+                .set_private_key_file(&key_path, SslFiletype::PEM)
+                .with_context(|| {
+                    format!("Failed to set private key file: {}", key_path.display())
+                })?;
+        }
+        Ok(builder.build())
+    }
+}


### PR DESCRIPTION
Introducing basic `-transport` support to cassandra-stress frontend.

- [x] - [test with dev version](https://argus.scylladb.com/tests/scylla-cluster-tests/0cd19b7e-fb77-4661-89b6-b17d6c812db9)


closes: https://github.com/scylladb/cql-stress/issues/136