### PR TITLE
fix: fix latency precision for fixed rate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,7 @@ dependencies = [
  "strum_macros",
  "thread_local",
  "tokio",
+ "tokio-timerfd",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -2075,6 +2076,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "timerfd"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84e482e368cf7efa2c8b570f476e5b9fd9fd5e9b9219fc567832b05f13511091"
+dependencies = [
+ "rustix",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,6 +2140,19 @@ checksum = "59df6849caa43bb7567f9a36f863c447d95a11d5903c9cc334ba32576a27eadd"
 dependencies = [
  "openssl",
  "openssl-sys",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-timerfd"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87eecdae9a9b793843b1df7a64bc136f203443c1ca9889b3c4a39590afa51094"
+dependencies = [
+ "futures-core",
+ "libc",
+ "slab",
+ "timerfd",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ tokio = { version = "1.15.0", features = [
     "fs",
     "signal",
 ] }
+tokio-timerfd = "0.2.0"
 tracing = "0.1.35"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 rust-strictmath = "0.1.1"

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -115,7 +115,7 @@ macro_rules! make_runnable {
         #[async_trait]
         impl$(<$($targ: $tbound),+>)? $crate::configuration::Operation for $op$(<$($targ),*>)? {
             async fn run(&mut self, mut session: $crate::run::WorkerSession) -> anyhow::Result<()> {
-                while let Some(ctx) = session.start_operation().await {
+                while let Some(ctx) = session.start_operation().await? {
                     let result = self.execute(&ctx).await;
                     if let std::ops::ControlFlow::Break(_) = session.end_operation(result)? {
                         return Ok(());


### PR DESCRIPTION
`tokio::sleep_until` operates on millisecond granularity. In result, if the sleep time is <1ms, we may sleep longer than expected.

Fix by using `tokio_timerfd` lib for precision sleep.

fixes: https://github.com/scylladb/cql-stress/issues/134