### PR TITLE
feat: add -errors option to the cassandra-stress frontend

### DIFF
--- a/src/bin/cql-stress-cassandra-stress/main.rs
+++ b/src/bin/cql-stress-cassandra-stress/main.rs
@@ -206,6 +206,9 @@ async fn prepare_run(
         }
     };
 
+    let max_retries_per_op = settings.errors.retries;
+    let ignore_errors = settings.errors.ignore;
+
     let operation_factory = create_operation_factory(session, settings, stats).await?;
 
     Ok(Configuration {
@@ -213,8 +216,8 @@ async fn prepare_run(
         concurrency,
         rate_limit_per_second: throttle,
         operation_factory,
-        // TODO: adjust when -errors option is supported
-        max_retries_per_op: 9,
+        max_retries_per_op,
+        ignore_errors,
     })
 }
 

--- a/src/bin/cql-stress-cassandra-stress/operation/mixed.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/mixed.rs
@@ -39,6 +39,7 @@ pub struct MixedOperation {
     clustering_distribution: Box<dyn Distribution>,
     current_operation: MixedSubcommand,
     current_operation_remaining: usize,
+    last_operation_id: Option<u64>,
 }
 
 pub struct MixedOperationFactory {
@@ -81,6 +82,7 @@ impl OperationFactory for MixedOperationFactory {
             clustering_distribution: mixed_params.clustering.create(),
             current_operation: MixedSubcommand::Read,
             current_operation_remaining: 0,
+            last_operation_id: None,
         })
     }
 }
@@ -172,6 +174,12 @@ impl MixedOperation {
             return Ok(ControlFlow::Break(()));
         }
 
+        if self.last_operation_id != Some(ctx.operation_id) {
+            self.last_operation_id = Some(ctx.operation_id);
+            self.cached_row = None;
+            self.current_operation_remaining = self.current_operation_remaining.saturating_sub(1);
+        }
+
         if self.current_operation_remaining == 0 {
             self.current_operation = self.operation_ratio.sample();
             self.current_operation_remaining =
@@ -237,11 +245,6 @@ impl MixedOperation {
                 result
             }
         };
-
-        if result.is_ok() {
-            self.current_operation_remaining -= 1;
-            self.cached_row = None;
-        }
 
         result
     }

--- a/src/bin/cql-stress-cassandra-stress/operation/mixed.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/mixed.rs
@@ -12,7 +12,6 @@ use cql_stress::{
     make_runnable,
 };
 use scylla::client::session::Session;
-use scylla::value::CqlValue;
 
 use super::{
     counter_write::{CounterWriteOperation, CounterWriteOperationFactory},
@@ -22,7 +21,7 @@ use super::{
     },
     row_generator::RowGenerator,
     write::{WriteOperation, WriteOperationFactory},
-    CassandraStressOperation, CassandraStressOperationFactory, RowGeneratorFactory,
+    CachedRow, CassandraStressOperation, CassandraStressOperationFactory, RowGeneratorFactory,
     DEFAULT_COUNTER_TABLE_NAME, DEFAULT_TABLE_NAME,
 };
 
@@ -31,15 +30,45 @@ pub struct MixedOperation {
     counter_write_operation: Option<CounterWriteOperation>,
     read_operation: Option<RegularReadOperation>,
     counter_read_operation: Option<CounterReadOperation>,
-    cached_row: Option<Vec<CqlValue>>,
+    cached_row: CachedRow,
     workload: RowGenerator,
     max_operations: Option<u64>,
     stats: Arc<ShardedStats>,
+    schedule: SubcommandSchedule,
+}
+
+struct SubcommandSchedule {
     operation_ratio: Arc<OperationRatio>,
     clustering_distribution: Box<dyn Distribution>,
-    current_operation: MixedSubcommand,
-    current_operation_remaining: usize,
-    last_operation_id: Option<u64>,
+    current: MixedSubcommand,
+    remaining: usize,
+}
+
+impl SubcommandSchedule {
+    fn new(
+        operation_ratio: Arc<OperationRatio>,
+        clustering_distribution: Box<dyn Distribution>,
+    ) -> Self {
+        Self {
+            operation_ratio,
+            clustering_distribution,
+            current: MixedSubcommand::Read,
+            remaining: 0,
+        }
+    }
+
+    fn advance(&mut self, started_new_operation: bool) -> MixedSubcommand {
+        if started_new_operation {
+            self.remaining = self.remaining.saturating_sub(1);
+        }
+
+        if self.remaining == 0 {
+            self.current = self.operation_ratio.sample();
+            self.remaining = (self.clustering_distribution.next_i64() as usize).max(1);
+        }
+
+        self.current
+    }
 }
 
 pub struct MixedOperationFactory {
@@ -74,15 +103,14 @@ impl OperationFactory for MixedOperationFactory {
             counter_write_operation,
             read_operation,
             counter_read_operation,
-            cached_row: None,
+            cached_row: CachedRow::default(),
             workload: self.workload_factory.create(),
             max_operations: self.max_operations,
             stats: Arc::clone(&self.stats),
-            operation_ratio: Arc::clone(&self.operation_ratio),
-            clustering_distribution: mixed_params.clustering.create(),
-            current_operation: MixedSubcommand::Read,
-            current_operation_remaining: 0,
-            last_operation_id: None,
+            schedule: SubcommandSchedule::new(
+                Arc::clone(&self.operation_ratio),
+                mixed_params.clustering.create(),
+            ),
         })
     }
 }
@@ -174,26 +202,19 @@ impl MixedOperation {
             return Ok(ControlFlow::Break(()));
         }
 
-        if self.last_operation_id != Some(ctx.operation_id) {
-            self.last_operation_id = Some(ctx.operation_id);
-            self.cached_row = None;
-            self.current_operation_remaining = self.current_operation_remaining.saturating_sub(1);
-        }
+        let started_new_operation = self.cached_row.begin_operation(ctx);
+        let current_operation = self.schedule.advance(started_new_operation);
 
-        if self.current_operation_remaining == 0 {
-            self.current_operation = self.operation_ratio.sample();
-            self.current_operation_remaining =
-                (self.clustering_distribution.next_i64() as usize).max(1);
-        }
+        let workload = &mut self.workload;
 
         // FIXME: Get rid of these unwraps once async traits are considered object-safe.
-        let result = match &self.current_operation {
+        let result = match current_operation {
             MixedSubcommand::Read => {
                 // This is safe. We create a given operation only if corresponding `MixedSubcommand` is defined in `operation_ratio` map.
                 let read_operation = self.read_operation.as_ref().unwrap();
                 let row = self
                     .cached_row
-                    .get_or_insert_with(|| read_operation.generate_row(&mut self.workload));
+                    .get_or_generate(|| read_operation.generate_row(workload));
                 let result = read_operation.execute(row).await;
                 self.stats.get_shard_mut().account_operation(
                     ctx,
@@ -207,7 +228,7 @@ impl MixedOperation {
                 let counter_read_operation = self.counter_read_operation.as_ref().unwrap();
                 let row = self
                     .cached_row
-                    .get_or_insert_with(|| counter_read_operation.generate_row(&mut self.workload));
+                    .get_or_generate(|| counter_read_operation.generate_row(workload));
                 let result = counter_read_operation.execute(row).await;
                 self.stats.get_shard_mut().account_operation(
                     ctx,
@@ -221,7 +242,7 @@ impl MixedOperation {
                 let write_operation = self.write_operation.as_ref().unwrap();
                 let row = self
                     .cached_row
-                    .get_or_insert_with(|| write_operation.generate_row(&mut self.workload));
+                    .get_or_generate(|| write_operation.generate_row(workload));
                 let result = write_operation.execute(row).await;
                 self.stats.get_shard_mut().account_operation(
                     ctx,
@@ -233,9 +254,9 @@ impl MixedOperation {
             MixedSubcommand::CounterWrite => {
                 // This is safe. We create a given operation only if corresponding `MixedSubcommand` is defined in `operation_ratio` map.
                 let counter_write_operation = self.counter_write_operation.as_ref().unwrap();
-                let row = self.cached_row.get_or_insert_with(|| {
-                    counter_write_operation.generate_row(&mut self.workload)
-                });
+                let row = self
+                    .cached_row
+                    .get_or_generate(|| counter_write_operation.generate_row(workload));
                 let result = counter_write_operation.execute(row).await;
                 self.stats.get_shard_mut().account_operation(
                     ctx,
@@ -247,5 +268,84 @@ impl MixedOperation {
         };
 
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use crate::java_generate::distribution::enumerated::EnumeratedDistribution;
+
+    use super::*;
+
+    struct ScriptedDistribution {
+        values: Mutex<std::collections::VecDeque<i64>>,
+    }
+
+    impl ScriptedDistribution {
+        fn boxed(values: &[i64]) -> Box<dyn Distribution> {
+            Box::new(Self {
+                values: Mutex::new(values.iter().copied().collect()),
+            })
+        }
+    }
+
+    impl Distribution for ScriptedDistribution {
+        fn next_i64(&self) -> i64 {
+            self.values
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("clustering distribution sampled more times than the test scripted")
+        }
+
+        fn next_f64(&self) -> f64 {
+            self.next_i64() as f64
+        }
+
+        fn set_seed(&self, _seed: i64) {}
+    }
+
+    fn schedule(clustering: &[i64]) -> SubcommandSchedule {
+        let ratio = EnumeratedDistribution::new(vec![(MixedSubcommand::Write, 1.0)]).unwrap();
+        SubcommandSchedule::new(Arc::new(ratio), ScriptedDistribution::boxed(clustering))
+    }
+
+    #[test]
+    fn burst_spans_exactly_the_sampled_number_of_operations() {
+        let mut schedule = schedule(&[2, 5]);
+
+        assert_eq!(MixedSubcommand::Write, schedule.advance(true));
+        assert_eq!(2, schedule.remaining);
+
+        assert_eq!(MixedSubcommand::Write, schedule.advance(true));
+        assert_eq!(1, schedule.remaining);
+
+        assert_eq!(MixedSubcommand::Write, schedule.advance(true));
+        assert_eq!(5, schedule.remaining);
+    }
+
+    #[test]
+    fn retries_do_not_consume_the_burst() {
+        let mut schedule = schedule(&[2]);
+
+        schedule.advance(true);
+        assert_eq!(2, schedule.remaining);
+
+        schedule.advance(false);
+        schedule.advance(false);
+        assert_eq!(2, schedule.remaining);
+    }
+
+    #[test]
+    fn zero_length_burst_runs_a_single_operation() {
+        let mut schedule = schedule(&[0, 0, 0]);
+
+        schedule.advance(true);
+        assert_eq!(1, schedule.remaining);
+
+        schedule.advance(true);
+        assert_eq!(1, schedule.remaining);
     }
 }

--- a/src/bin/cql-stress-cassandra-stress/operation/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/mod.rs
@@ -71,6 +71,28 @@ pub trait CassandraStressOperationFactory: Sync + Send + Sized {
     fn create(&self) -> Self::Operation;
 }
 
+#[derive(Default)]
+pub struct CachedRow {
+    row: Option<Vec<CqlValue>>,
+    last_operation_id: Option<u64>,
+}
+
+impl CachedRow {
+    pub fn begin_operation(&mut self, ctx: &OperationContext) -> bool {
+        if self.last_operation_id == Some(ctx.operation_id) {
+            return false;
+        }
+
+        self.last_operation_id = Some(ctx.operation_id);
+        self.row = None;
+        true
+    }
+
+    pub fn get_or_generate(&mut self, generate: impl FnOnce() -> Vec<CqlValue>) -> &[CqlValue] {
+        self.row.get_or_insert_with(generate)
+    }
+}
+
 /// Generic CassandraStress operation.
 ///
 /// It handles the common logic for all of the operations, such as:
@@ -84,11 +106,7 @@ pub struct GenericCassandraStressOperation<O: CassandraStressOperation> {
     stats: Arc<ShardedStats>,
     workload: RowGenerator,
     max_operations: Option<u64>,
-    // The operation may need to be retried.
-    // This is why we cache the row so it can be used
-    // during the retry.
-    cached_row: Option<Vec<CqlValue>>,
-    last_operation_id: Option<u64>,
+    cached_row: CachedRow,
 }
 
 make_runnable!(GenericCassandraStressOperation<O: CassandraStressOperation>);
@@ -101,14 +119,13 @@ impl<O: CassandraStressOperation> GenericCassandraStressOperation<O> {
             return Ok(ControlFlow::Break(()));
         }
 
-        if self.last_operation_id != Some(ctx.operation_id) {
-            self.last_operation_id = Some(ctx.operation_id);
-            self.cached_row = None;
-        }
+        self.cached_row.begin_operation(ctx);
 
+        let cs_operation = &self.cs_operation;
+        let workload = &mut self.workload;
         let row = self
             .cached_row
-            .get_or_insert_with(|| self.cs_operation.generate_row(&mut self.workload));
+            .get_or_generate(|| cs_operation.generate_row(workload));
 
         let op_result = self.cs_operation.execute(row).await;
         self.stats.get_shard_mut().account_operation(
@@ -227,8 +244,7 @@ impl<O: CassandraStressOperation + 'static> OperationFactory
             stats: Arc::clone(&self.stats),
             workload: self.workload_factory.create(),
             max_operations: self.max_operations,
-            cached_row: None,
-            last_operation_id: None,
+            cached_row: CachedRow::default(),
         })
     }
 }
@@ -453,8 +469,7 @@ mod tests {
             stats: Arc::new(ShardedStats::new(stats_factory)),
             workload: RowGeneratorFactory::new(Arc::clone(&settings)).create(),
             max_operations: None,
-            cached_row: None,
-            last_operation_id: None,
+            cached_row: CachedRow::default(),
         };
 
         operation

--- a/src/bin/cql-stress-cassandra-stress/operation/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/mod.rs
@@ -88,6 +88,7 @@ pub struct GenericCassandraStressOperation<O: CassandraStressOperation> {
     // This is why we cache the row so it can be used
     // during the retry.
     cached_row: Option<Vec<CqlValue>>,
+    last_operation_id: Option<u64>,
 }
 
 make_runnable!(GenericCassandraStressOperation<O: CassandraStressOperation>);
@@ -100,6 +101,11 @@ impl<O: CassandraStressOperation> GenericCassandraStressOperation<O> {
             return Ok(ControlFlow::Break(()));
         }
 
+        if self.last_operation_id != Some(ctx.operation_id) {
+            self.last_operation_id = Some(ctx.operation_id);
+            self.cached_row = None;
+        }
+
         let row = self
             .cached_row
             .get_or_insert_with(|| self.cs_operation.generate_row(&mut self.workload));
@@ -110,12 +116,6 @@ impl<O: CassandraStressOperation> GenericCassandraStressOperation<O> {
             &op_result,
             self.cs_operation.operation_tag(),
         );
-
-        if op_result.is_ok() {
-            // Operation was successful - we will generate new row
-            // for the next operation.
-            self.cached_row = None;
-        }
 
         op_result
     }
@@ -228,6 +228,7 @@ impl<O: CassandraStressOperation + 'static> OperationFactory
             workload: self.workload_factory.create(),
             max_operations: self.max_operations,
             cached_row: None,
+            last_operation_id: None,
         })
     }
 }
@@ -376,5 +377,102 @@ impl<T> OperationSampler<T> {
 
     pub fn previous_sample(&self) -> &T {
         &self.items[self.current_item_index]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use tokio::time::Instant;
+
+    use super::*;
+    use crate::settings::{parse_cassandra_stress_args, CassandraStressParsingResult};
+    use crate::stats::StatsFactory;
+
+    struct FailingOperationFactory {
+        executed_rows: Arc<Mutex<Vec<Vec<CqlValue>>>>,
+    }
+
+    struct FailingOperation {
+        executed_rows: Arc<Mutex<Vec<Vec<CqlValue>>>>,
+    }
+
+    impl CassandraStressOperationFactory for FailingOperationFactory {
+        type Operation = FailingOperation;
+
+        fn create(&self) -> Self::Operation {
+            FailingOperation {
+                executed_rows: Arc::clone(&self.executed_rows),
+            }
+        }
+    }
+
+    impl CassandraStressOperation for FailingOperation {
+        type Factory = FailingOperationFactory;
+
+        async fn execute(&self, row: &[CqlValue]) -> Result<ControlFlow<()>> {
+            self.executed_rows.lock().unwrap().push(row.to_vec());
+            Err(anyhow::anyhow!("operation failed"))
+        }
+
+        fn generate_row(&self, row_generator: &mut RowGenerator) -> Vec<CqlValue> {
+            row_generator.generate_row()
+        }
+
+        fn operation_tag(&self) -> &'static str {
+            "TEST"
+        }
+    }
+
+    fn make_operation_context(operation_id: u64) -> OperationContext {
+        let now = Instant::now();
+        OperationContext {
+            operation_id,
+            scheduled_start_time: now,
+            actual_start_time: now,
+        }
+    }
+
+    #[tokio::test]
+    async fn generic_operation_regenerates_row_for_new_operation_id() {
+        let args =
+            "cql-stress-cassandra-stress write n=100 -node 127.0.0.1".split_ascii_whitespace();
+        let settings = match parse_cassandra_stress_args(args).unwrap() {
+            CassandraStressParsingResult::Workload(settings) => Arc::new(*settings),
+            CassandraStressParsingResult::SpecialCommand => panic!("Expected a workload"),
+        };
+
+        let executed_rows = Arc::new(Mutex::new(Vec::new()));
+        let stats_factory = Arc::new(StatsFactory::new(&settings));
+        let mut operation = GenericCassandraStressOperation {
+            cs_operation: FailingOperationFactory {
+                executed_rows: Arc::clone(&executed_rows),
+            }
+            .create(),
+            stats: Arc::new(ShardedStats::new(stats_factory)),
+            workload: RowGeneratorFactory::new(Arc::clone(&settings)).create(),
+            max_operations: None,
+            cached_row: None,
+            last_operation_id: None,
+        };
+
+        operation
+            .execute(&make_operation_context(0))
+            .await
+            .unwrap_err();
+        operation
+            .execute(&make_operation_context(0))
+            .await
+            .unwrap_err();
+        operation
+            .execute(&make_operation_context(1))
+            .await
+            .unwrap_err();
+
+        let rows = executed_rows.lock().unwrap();
+        assert_eq!(3, rows.len());
+        assert_eq!(rows[0], rows[1]);
+        assert_ne!(rows[1], rows[2]);
     }
 }

--- a/src/bin/cql-stress-cassandra-stress/operation/user.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/user.rs
@@ -88,6 +88,7 @@ pub struct UserOperation {
     stats: Arc<ShardedStats>,
     max_operations: Option<u64>,
     cached_row: Option<Vec<CqlValue>>,
+    last_operation_id: Option<u64>,
 }
 
 make_runnable!(UserOperation);
@@ -98,6 +99,11 @@ impl UserOperation {
             .is_some_and(|max_ops| ctx.operation_id >= max_ops)
         {
             return Ok(ControlFlow::Break(()));
+        }
+
+        if self.last_operation_id != Some(ctx.operation_id) {
+            self.last_operation_id = Some(ctx.operation_id);
+            self.cached_row = None;
         }
 
         let (op, row) = match &mut self.cached_row {
@@ -114,12 +120,6 @@ impl UserOperation {
         self.stats
             .get_shard_mut()
             .account_operation(ctx, &op_result, op.operation_tag());
-
-        if op_result.is_ok() {
-            // Operation was successful - we will generate new row
-            // for the next operation.
-            self.cached_row = None;
-        }
 
         op_result
     }
@@ -331,6 +331,7 @@ impl OperationFactory for UserOperationFactory {
             max_operations: self.max_operations,
             sampler,
             cached_row: None,
+            last_operation_id: None,
         })
     }
 }

--- a/src/bin/cql-stress-cassandra-stress/operation/user.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/user.rs
@@ -21,8 +21,8 @@ use crate::{
 };
 
 use super::{
-    row_generator::RowGenerator, CassandraStressOperation, CassandraStressOperationFactory,
-    OperationSampler,
+    row_generator::RowGenerator, CachedRow, CassandraStressOperation,
+    CassandraStressOperationFactory, OperationSampler,
 };
 
 const SEED_STR: &str = "seed for stress";
@@ -87,8 +87,7 @@ pub struct UserOperation {
     workload: RowGenerator,
     stats: Arc<ShardedStats>,
     max_operations: Option<u64>,
-    cached_row: Option<Vec<CqlValue>>,
-    last_operation_id: Option<u64>,
+    cached_row: CachedRow,
 }
 
 make_runnable!(UserOperation);
@@ -101,19 +100,16 @@ impl UserOperation {
             return Ok(ControlFlow::Break(()));
         }
 
-        if self.last_operation_id != Some(ctx.operation_id) {
-            self.last_operation_id = Some(ctx.operation_id);
-            self.cached_row = None;
-        }
-
-        let (op, row) = match &mut self.cached_row {
-            Some(cached_row) => (self.sampler.previous_sample(), cached_row),
-            None => {
-                let op = self.sampler.sample();
-                let row = self.cached_row.insert(op.generate_row(&mut self.workload));
-                (op, row)
-            }
+        let op = if self.cached_row.begin_operation(ctx) {
+            self.sampler.sample()
+        } else {
+            self.sampler.previous_sample()
         };
+
+        let workload = &mut self.workload;
+        let row = self
+            .cached_row
+            .get_or_generate(|| op.generate_row(workload));
 
         let op_result = op.execute(row).await;
 
@@ -330,8 +326,7 @@ impl OperationFactory for UserOperationFactory {
             stats: Arc::clone(&self.stats),
             max_operations: self.max_operations,
             sampler,
-            cached_row: None,
-            last_operation_id: None,
+            cached_row: CachedRow::default(),
         })
     }
 }

--- a/src/bin/cql-stress-cassandra-stress/settings/command/mixed.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/command/mixed.rs
@@ -12,7 +12,7 @@ use anyhow::{Context, Result};
 use super::{common::CommonParamHandles, counter::CounterParams, Command, CommandParams};
 
 // Available subcommands for mixed command.
-#[derive(Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum MixedSubcommand {
     Read,
     Write,

--- a/src/bin/cql-stress-cassandra-stress/settings/cs_args_bad_test.in
+++ b/src/bin/cql-stress-cassandra-stress/settings/cs_args_bad_test.in
@@ -56,3 +56,12 @@ cassandra-stress write -transport foo=bar
 cassandra-stress write -transport garbage
 
 # --- END: SSL/TLS -transport negative cases ---
+
+# --- BEGIN: -errors negative cases ---
+cassandra-stress write -errors ignore=true
+cassandra-stress write -errors retries=foo
+cassandra-stress write -errors ignore fail-fast
+cassandra-stress write -errors delay-policy=
+cassandra-stress write -errors min-delay-ms=fast
+cassandra-stress write -errors foo
+# --- END: -errors negative cases ---

--- a/src/bin/cql-stress-cassandra-stress/settings/cs_args_good_test.in
+++ b/src/bin/cql-stress-cassandra-stress/settings/cs_args_good_test.in
@@ -62,3 +62,13 @@ cassandra-stress write -transport hostname-verification=true
 # Only -transport with no suboptions (should be accepted and default to no SSL)
 cassandra-stress write -transport
 # --- END: SSL/TLS -transport positive cases ---
+
+# --- BEGIN: -errors positive cases ---
+cassandra-stress write -errors ignore
+cassandra-stress write -errors retries=20
+cassandra-stress read -errors ignore retries=3
+cassandra-stress write -errors fail-fast
+cassandra-stress write -errors skip-unsupported-columns
+cassandra-stress write -errors ignore skip-read-validation skip-unsupported-columns
+cassandra-stress write -errors ignore retries=3 delay-policy=fixed min-delay-ms=10 max-delay-ms=1000
+# --- END: -errors positive cases ---

--- a/src/bin/cql-stress-cassandra-stress/settings/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/mod.rs
@@ -16,6 +16,7 @@ pub use command::MixedSubcommand;
 pub use command::OperationRatio;
 #[cfg(feature = "user-profile")]
 pub use command::{OpWeight, PREDEFINED_INSERT_OPERATION};
+pub use option::ErrorsOption;
 pub use option::LogOption;
 pub use option::ThreadsInfo;
 use regex::Regex;
@@ -43,6 +44,7 @@ pub struct CassandraStressSettings {
     pub population: PopulationOption,
     pub log: LogOption,
     pub transport: TransportOption,
+    pub errors: ErrorsOption,
 }
 
 impl CassandraStressSettings {
@@ -57,6 +59,7 @@ impl CassandraStressSettings {
         self.population.print_settings();
         self.log.print_settings();
         self.transport.print_settings();
+        self.errors.print_settings();
         println!();
     }
 
@@ -221,6 +224,7 @@ where
         let column = ColumnOption::parse(&mut payload)?;
         let log = LogOption::parse(&mut payload)?;
         let transport = TransportOption::parse(&mut payload)?;
+        let errors = ErrorsOption::parse(&mut payload)?;
 
         // The default distribution (if not specified) is SEQ(1..operation_count).
         // If operation_count is not specified, then the default is 1M.
@@ -262,6 +266,7 @@ where
                 population,
                 log,
                 transport,
+                errors,
             },
         )))
     };

--- a/src/bin/cql-stress-cassandra-stress/settings/option/errors.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/option/errors.rs
@@ -1,0 +1,262 @@
+use anyhow::{Context, Result};
+
+use crate::settings::{
+    param::{types::NonEmptyString, ParamsParser, SimpleParamHandle},
+    ParsePayload,
+};
+
+pub const DEFAULT_RETRIES_PER_OPERATION: usize = 9;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ErrorsOption {
+    pub ignore: bool,
+    pub retries: usize,
+}
+
+impl Default for ErrorsOption {
+    fn default() -> Self {
+        Self {
+            ignore: false,
+            retries: DEFAULT_RETRIES_PER_OPERATION,
+        }
+    }
+}
+
+impl ErrorsOption {
+    pub const CLI_STRING: &'static str = "-errors";
+
+    pub fn description() -> &'static str {
+        "How to handle operation errors"
+    }
+
+    pub fn parse(cl_args: &mut ParsePayload) -> Result<Self> {
+        let params = cl_args.remove(Self::CLI_STRING).unwrap_or_default();
+        let (parser, handles) = prepare_parser();
+        parser
+            .parse(params)
+            .context("Failed to parse -errors option parameters")?;
+        Self::from_handles(handles)
+    }
+
+    pub fn print_help() {
+        let (parser, _) = prepare_parser();
+        parser.print_help();
+    }
+
+    pub fn print_settings(&self) {
+        println!("Errors:");
+        println!("  Ignore: {}", self.ignore);
+        println!("  Retries: {}", self.retries);
+    }
+
+    fn from_handles(handles: ErrorsParamHandles) -> Result<Self> {
+        let ignore = handles.ignore.get().unwrap_or(false);
+        let fail_fast = handles.fail_fast.get().unwrap_or(false);
+        anyhow::ensure!(
+            !(ignore && fail_fast),
+            "ignore and fail-fast are mutually exclusive"
+        );
+
+        let retries = handles
+            .retries
+            .get()
+            .unwrap_or(DEFAULT_RETRIES_PER_OPERATION);
+
+        warn_ignored("skip-read-validation", handles.skip_read_validation.get());
+        warn_ignored(
+            "skip-unsupported-columns",
+            handles.skip_unsupported_columns.get(),
+        );
+        warn_ignored("delay-policy", handles.delay_policy.get());
+        warn_ignored("min-delay-ms", handles.min_delay_ms.get());
+        warn_ignored("max-delay-ms", handles.max_delay_ms.get());
+
+        Ok(Self { ignore, retries })
+    }
+}
+
+fn warn_ignored<T>(name: &str, supplied: Option<T>) {
+    if supplied.is_some() {
+        tracing::warn!("-errors {name} is not supported and will be ignored");
+    }
+}
+
+struct ErrorsParamHandles {
+    ignore: SimpleParamHandle<bool>,
+    fail_fast: SimpleParamHandle<bool>,
+    retries: SimpleParamHandle<usize>,
+    skip_read_validation: SimpleParamHandle<bool>,
+    skip_unsupported_columns: SimpleParamHandle<bool>,
+    delay_policy: SimpleParamHandle<NonEmptyString>,
+    min_delay_ms: SimpleParamHandle<usize>,
+    max_delay_ms: SimpleParamHandle<usize>,
+}
+
+fn prepare_parser() -> (ParamsParser, ErrorsParamHandles) {
+    let mut parser = ParamsParser::new(ErrorsOption::CLI_STRING);
+
+    let ignore = parser.simple_param::<bool>(
+        "ignore",
+        None,
+        "Do not stop the benchmark when an operation keeps failing",
+        false,
+    );
+
+    let fail_fast = parser.simple_param::<bool>(
+        "fail-fast",
+        None,
+        "Stop the benchmark when an operation keeps failing (default)",
+        false,
+    );
+
+    let default_retries = DEFAULT_RETRIES_PER_OPERATION.to_string();
+    let retries = parser.simple_param::<usize>(
+        "retries=",
+        Some(&default_retries),
+        "Number of times to retry a failed operation before giving up on it",
+        false,
+    );
+
+    let skip_read_validation = parser.simple_param::<bool>(
+        "skip-read-validation",
+        None,
+        "Do not validate the rows that a read returns (unsupported)",
+        false,
+    );
+
+    let skip_unsupported_columns = parser.simple_param::<bool>(
+        "skip-unsupported-columns",
+        None,
+        "Skip the columns of a type the driver cannot handle (unsupported)",
+        false,
+    );
+
+    let delay_policy = parser.simple_param::<NonEmptyString>(
+        "delay-policy=",
+        None,
+        "Backoff policy between the retries of an operation (unsupported)",
+        false,
+    );
+
+    let min_delay_ms = parser.simple_param::<usize>(
+        "min-delay-ms=",
+        None,
+        "Shortest backoff between the retries of an operation (unsupported)",
+        false,
+    );
+
+    let max_delay_ms = parser.simple_param::<usize>(
+        "max-delay-ms=",
+        None,
+        "Longest backoff between the retries of an operation (unsupported)",
+        false,
+    );
+
+    parser.group(&[
+        &ignore,
+        &fail_fast,
+        &retries,
+        &skip_read_validation,
+        &skip_unsupported_columns,
+        &delay_policy,
+        &min_delay_ms,
+        &max_delay_ms,
+    ]);
+
+    (
+        parser,
+        ErrorsParamHandles {
+            ignore,
+            fail_fast,
+            retries,
+            skip_read_validation,
+            skip_unsupported_columns,
+            delay_policy,
+            min_delay_ms,
+            max_delay_ms,
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{prepare_parser, ErrorsOption};
+
+    fn parse(args: Vec<&str>) -> anyhow::Result<ErrorsOption> {
+        let (parser, handles) = prepare_parser();
+        parser.parse(args)?;
+        ErrorsOption::from_handles(handles)
+    }
+
+    #[test]
+    fn errors_default_params_test() {
+        assert_eq!(ErrorsOption::default(), parse(vec![]).unwrap());
+    }
+
+    #[test]
+    fn errors_ignore_test() {
+        let params = parse(vec!["ignore"]).unwrap();
+        assert!(params.ignore);
+        assert_eq!(9, params.retries);
+    }
+
+    #[test]
+    fn errors_retries_test() {
+        let params = parse(vec!["retries=20"]).unwrap();
+        assert!(!params.ignore);
+        assert_eq!(20, params.retries);
+    }
+
+    #[test]
+    fn errors_ignore_and_retries_test() {
+        let params = parse(vec!["ignore", "retries=3"]).unwrap();
+        assert!(params.ignore);
+        assert_eq!(3, params.retries);
+    }
+
+    #[test]
+    fn errors_fail_fast_test() {
+        let params = parse(vec!["fail-fast"]).unwrap();
+        assert!(!params.ignore);
+    }
+
+    #[test]
+    fn errors_fail_fast_conflicts_with_ignore_test() {
+        assert!(parse(vec!["ignore", "fail-fast"]).is_err());
+    }
+
+    #[test]
+    fn errors_unsupported_suboptions_are_accepted_test() {
+        let args = vec![
+            "ignore",
+            "skip-read-validation",
+            "skip-unsupported-columns",
+            "delay-policy=fixed",
+            "min-delay-ms=10",
+            "max-delay-ms=1000",
+        ];
+        let params = parse(args).unwrap();
+        assert!(params.ignore);
+        assert_eq!(9, params.retries);
+    }
+
+    #[test]
+    fn errors_bad_retries_test() {
+        assert!(parse(vec!["retries=foo"]).is_err());
+    }
+
+    #[test]
+    fn errors_empty_delay_policy_test() {
+        assert!(parse(vec!["delay-policy="]).is_err());
+    }
+
+    #[test]
+    fn errors_ignore_with_value_test() {
+        assert!(parse(vec!["ignore=true"]).is_err());
+    }
+
+    #[test]
+    fn errors_unknown_param_test() {
+        assert!(parse(vec!["foo"]).is_err());
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/settings/option/mod.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/option/mod.rs
@@ -1,4 +1,5 @@
 mod column;
+mod errors;
 mod log;
 mod mode;
 mod node;
@@ -10,6 +11,7 @@ mod transport;
 use anyhow::Result;
 
 pub use column::ColumnOption;
+pub use errors::ErrorsOption;
 pub use log::LogOption;
 pub use mode::ModeOption;
 pub use node::NodeOption;
@@ -34,6 +36,7 @@ impl Options {
                 PopulationOption::description(),
             ),
             (LogOption::CLI_STRING, LogOption::description()),
+            (ErrorsOption::CLI_STRING, ErrorsOption::description()),
             (TransportOption::CLI_STRING, TransportOption::description()),
         ]
         .into_iter()
@@ -55,6 +58,7 @@ impl Options {
             PopulationOption::CLI_STRING => PopulationOption::print_help(),
             ModeOption::CLI_STRING => ModeOption::print_help(),
             LogOption::CLI_STRING => LogOption::print_help(),
+            ErrorsOption::CLI_STRING => ErrorsOption::print_help(),
             TransportOption::CLI_STRING => {
                 TransportOption::print_help();
             }

--- a/src/bin/cql-stress-cassandra-stress/settings/param/types.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/param/types.rs
@@ -53,6 +53,16 @@ impl Parsable for u64 {
     }
 }
 
+impl Parsable for usize {
+    type Parsed = usize;
+
+    fn parse(s: &str) -> Result<Self::Parsed> {
+        ensure_regex!(s, r"^[0-9]+$");
+        s.parse::<usize>()
+            .with_context(|| format!("Invalid usize value: {s}"))
+    }
+}
+
 impl Parsable for NonZeroUsize {
     type Parsed = NonZeroUsize;
 

--- a/src/bin/cql-stress-scylla-bench/main.rs
+++ b/src/bin/cql-stress-scylla-bench/main.rs
@@ -169,6 +169,7 @@ async fn prepare(args: Arc<ScyllaBenchArgs>, stats: Arc<ShardedStats>) -> Result
         rate_limit_per_second,
         operation_factory,
         max_retries_per_op: args.max_retries_per_op as usize,
+        ignore_errors: false,
     })
 }
 

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -36,6 +36,11 @@ pub struct Configuration {
     /// The maximum number of attempts an operation should be retried
     /// before giving up.
     pub max_retries_per_op: usize,
+
+    /// Continues the run when an operation keeps failing after
+    /// `max_retries_per_op` attempts. The failed operation is abandoned
+    /// and the worker proceeds with the next one.
+    pub ignore_errors: bool,
 }
 
 /// Contains all necessary context needed to execute an Operation.

--- a/src/run.rs
+++ b/src/run.rs
@@ -55,6 +55,7 @@ struct WorkerContext {
 
     rate_limiter: Option<RateLimiter>,
     max_retries_per_op: usize,
+    ignore_errors: bool,
 }
 
 impl WorkerContext {
@@ -66,6 +67,7 @@ impl WorkerContext {
                 .rate_limit_per_second
                 .map(|rate| RateLimiter::new(now, rate)),
             max_retries_per_op: config.max_retries_per_op,
+            ignore_errors: config.ignore_errors,
         }
     }
 
@@ -140,13 +142,25 @@ impl WorkerSession {
                 self.trial_idx = 0;
                 Ok(flow)
             }
-            Err(err) if self.trial_idx >= self.context.max_retries_per_op => Err(err),
-            Err(err) if self.context.should_stop() => Err(err),
+            Err(err) if self.trial_idx >= self.context.max_retries_per_op => {
+                self.give_up_on_operation(err)
+            }
+            Err(err) if self.context.should_stop() => self.give_up_on_operation(err),
             Err(_) => {
                 self.trial_idx += 1;
                 Ok(ControlFlow::Continue(()))
             }
         }
+    }
+
+    fn give_up_on_operation(&mut self, err: anyhow::Error) -> Result<ControlFlow<()>> {
+        if !self.context.ignore_errors {
+            return Err(err);
+        }
+
+        tracing::error!("Operation failed, ignoring the error: {:?}", err);
+        self.trial_idx = 0;
+        Ok(ControlFlow::Continue(()))
     }
 }
 
@@ -321,6 +335,7 @@ mod tests {
             rate_limit_per_second: None,
             operation_factory: Arc::new(FnOperationFactory(f)),
             max_retries_per_op: 0,
+            ignore_errors: false,
         }
     }
 
@@ -489,6 +504,37 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(10)).await; // Make sure we don't enter a spin loop
             Err(anyhow::anyhow!("fail"))
         }
+    }
+
+    #[tokio::test]
+    #[ntest::timeout(1000)]
+    async fn test_ignore_errors_on_constant_failures() {
+        let mut cfg = make_test_cfg(|| AlwaysFailsOp(None));
+        cfg.max_duration = Some(Duration::from_millis(100));
+        cfg.max_retries_per_op = 1;
+        cfg.ignore_errors = true;
+
+        let (_, fut) = run(cfg);
+        fut.await.unwrap();
+    }
+
+    #[tokio::test]
+    #[ntest::timeout(1000)]
+    async fn test_ignore_errors_when_asked_to_stop() {
+        let sem = Arc::new(Semaphore::new(0));
+        let sem_clone = Arc::clone(&sem);
+
+        let mut cfg = make_test_cfg(move || AlwaysFailsOp(Some(sem_clone.clone())));
+        cfg.max_retries_per_op = usize::MAX;
+        cfg.ignore_errors = true;
+        let concurrency = cfg.concurrency as u32;
+
+        let (ctrl, fut) = run(cfg);
+
+        let _ = sem.acquire_many(concurrency).await.unwrap();
+
+        ctrl.ask_to_stop();
+        fut.await.unwrap();
     }
 
     #[tokio::test]

--- a/tools/cql-stress-cassandra-stress-ci.py
+++ b/tools/cql-stress-cassandra-stress-ci.py
@@ -6,6 +6,7 @@ from util.cassandra_stress import CassandraStress, CqlStressCassandraStress, CSC
 from test_cs_write_and_validate import run as run_write_and_validate
 from test_cs_equal_db import run as run_equal_db, run_user
 from test_hdr_logging import run as run_hdr_logging
+from test_cs_errors_ignore import run as run_errors_ignore
 
 
 # Utils for test cases
@@ -50,6 +51,11 @@ def test_write_and_validate_with_hdr_log(hdr_log_runtime_args, scylla_docker_nod
                                         cql_stress):
     run_hdr_logging(runtime_args=hdr_log_runtime_args, node=scylla_docker_node,
                            cql_stress=cql_stress)
+
+
+def test_errors_ignore(default_runtime_args, scylla_docker_node, cql_stress):
+    run_errors_ignore(runtime_args=default_runtime_args, node=scylla_docker_node,
+                      cql_stress=cql_stress)
 
 
 def test_equal_db(default_runtime_args, scylla_docker_node,

--- a/tools/test_cs_errors_ignore.py
+++ b/tools/test_cs_errors_ignore.py
@@ -1,0 +1,100 @@
+#! /usr/bin/env python3
+
+import subprocess
+
+from util.cassandra_stress import (
+    CqlStressCassandraStress,
+    CSCliRuntimeArguments,
+    generate_random_keyspaces,
+)
+from util.scylla_docker import ScyllaDockerNode
+
+
+def prepare_missing_rows_read_args(
+    node_ip, keyspace, runtime_args: CSCliRuntimeArguments, error_args
+):
+    workload_size = int(runtime_args.workload_size)
+    population_start = workload_size + 1
+    population_end = 2 * workload_size
+
+    return [
+        "read",
+        "no-warmup",
+        f"n={workload_size}",
+        "-node",
+        node_ip,
+        "-rate",
+        f"threads={runtime_args.concurrency}",
+        "-schema",
+        f"keyspace={keyspace}",
+        "-pop",
+        f"seq={population_start}..{population_end}",
+    ] + error_args
+
+
+def parse_total_errors(output):
+    for line in output.splitlines():
+        if line.startswith("Total errors"):
+            return int(line.split(":")[1].strip())
+    return None
+
+
+def run(
+    runtime_args: CSCliRuntimeArguments,
+    node: ScyllaDockerNode,
+    cql_stress: CqlStressCassandraStress,
+):
+    keyspaces = generate_random_keyspaces()
+    ks_cqlstress = keyspaces.ks_cqlstress
+
+    print("\n=== Starting the -errors ignore test... ===")
+
+    cql_stress.run(
+        command="write",
+        node_ip=node.ip,
+        keyspace=ks_cqlstress,
+        runtime_args=runtime_args,
+    )
+
+    print("\n=== Reading the rows that were never inserted ===\n")
+    failing_run = subprocess.run(
+        args=cql_stress.stress_cmd
+        + prepare_missing_rows_read_args(node.ip, ks_cqlstress, runtime_args, []),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    print(failing_run.stdout)
+
+    if failing_run.returncode == 0:
+        raise RuntimeError(
+            "The benchmark must fail when the read errors are not ignored. "
+            f"Stderr: {failing_run.stderr}"
+        )
+
+    print("\n=== Reading the same rows with -errors ignore ===\n")
+    ignoring_run = subprocess.run(
+        args=cql_stress.stress_cmd
+        + prepare_missing_rows_read_args(
+            node.ip, ks_cqlstress, runtime_args, ["-errors", "ignore", "retries=1"]
+        ),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    print(ignoring_run.stdout)
+
+    if ignoring_run.returncode != 0:
+        raise RuntimeError(
+            f"The benchmark must succeed with -errors ignore. Stderr: {ignoring_run.stderr}"
+        )
+
+    total_errors = parse_total_errors(ignoring_run.stdout)
+    if total_errors is None:
+        raise RuntimeError("The summary must contain a 'Total errors' line")
+    if total_errors == 0:
+        raise RuntimeError("The summary must report the ignored errors, but reports 0")
+
+    print(
+        f"\n=== -errors ignore test successful ({total_errors} errors reported) ===\n"
+    )


### PR DESCRIPTION
A longevity test that kills a node with `KillMVBuildingCoordinator` failed the whole benchmark on a `read_failure` error. The replicas of a read are chosen when the read starts, so a replica that dies mid-read makes the coordinator return that error. Every error that survives the retries stops the run, and the retry count was fixed at 9 with no way to change it. A test that kills nodes on purpose reports a false failure.

The `-errors` option accepts `ignore` and `retries=N`, as the original cassandra-stress does. With `ignore`, the worker abandons the operation, records the error in the statistics and continues. The abandoned operation must not keep its cached row, so the row is now bound to the operation id in the write, read, mixed and user workloads.

The integration tests here need #196 to reach the keyspace creation.

Closes QATOOLS-358