### PR TITLE
ci: create the test keyspaces with NetworkTopologyStrategy

### DIFF
--- a/tools/util/cassandra_stress.py
+++ b/tools/util/cassandra_stress.py
@@ -35,7 +35,8 @@ def prepare_args(command, node_ip, keyspace, runtime_args: CSCliRuntimeArguments
         rate_args.append(f"throttle={runtime_args.throttle}")
     args.extend(["-rate"] + rate_args)
     
-    args.extend(["-schema", f"keyspace={keyspace}"])
+    args.extend(["-schema", "replication(strategy=NetworkTopologyStrategy)",
+                 f"keyspace={keyspace}"])
 
     # Add HDR logging options if specified
     if runtime_args.hdr_log_file:


### PR DESCRIPTION
Scylla enables tablets by default and rejects `SimpleStrategy`. The integration tests in `tools/` create the keyspace through the cassandra-stress frontend, and `-schema` defaults to `SimpleStrategy`, so every test stopped at the keyspace creation. This blocks the integration-tests job on every pull request, not only on one branch.

The tests now pass `replication(strategy=NetworkTopologyStrategy)` to `-schema`.